### PR TITLE
Hardening: implement review findings #39–#52

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -185,15 +185,46 @@ ptyunit/
 ## Session handoff notes
 > Update this section at the end of each session.
 
-_Last updated: 2026-03-26 (session 29)_
+_Last updated: 2026-08-24 (session 30 — review triage + implementation)_
 
-**617/617 assertions pass (unit). v1.5.3 current. Hardening complete. Consumer validated.**
+**724/724 unit + 37/37 integration assertions pass. v1.5.4 on main; 13 commits on branch `hardening/review-2026-08` (unmerged, unpushed).**
 
 ---
 
 ### Next session: pick up here
 
-**State:** All hardening-complete issues (#36–#38) closed. v1.5.3 released. No open tickets.
+**State:** An external review (2026-08-24) was verified against the source, filed as issues #39–#52, and **all 14 are implemented on `hardening/review-2026-08`** with TDD (failing self-test first for each). Two of the review's "exclusions" (no TAP/JUnit, no parallel runner) were wrong — both already existed — and were not filed. Two bugs the review missed were found while verifying it (#43, #44).
+
+**Completed this session (session 30), in commit order:**
+
+| Commit | Issues | What |
+|--------|--------|------|
+| `c5fa47b` | #39 #40 #42 | mock.sh: re-mock leak (save original once, dedupe registry, forget on unmock), name validation (`^[A-Za-z_][A-Za-z0-9_.-]*$`, rc 2), PATH cleanup strips only the mock bin dir |
+| `c290b9f` | #44 | `pty_run.coverage_bash_env_script()` shared with PTYSession; bash-4.1 guard on both drivers (was missing in pty_run → 3.2 child spewed xtrace into PTY); guard now includes bash 5.0 |
+| `8255220` | #43 | coverage.sh exits 2 on bash < 4.1 instead of reporting 0%; header comment and README corrected (no 3.2 fallback ever existed) |
+| `00dcba7` | #45 | `strip_ansi()` drops a trailing incomplete escape *before* ANSI_RE (Fe catch-all otherwise leaks truncated OSC/DCS payload) |
+| `c0e5320` | #41 | function-mock heredoc bodies run in-process (`source` inside a helper fn → `local`/`return` work); command mocks unchanged; docblock states which is which |
+| `38e03c5` | #46 | docs: PTY_INIT ignored since v1.5.2, scripts run via `bash <script>`, Windows = WSL only |
+| `154559b` | #49 | `test_each --sep CHAR`; no-escape and trailing-empty-field rules documented |
+| `3ba3fce` | #52 | `assert_float_eq/gt/lt/ge/le` (awk, tolerance, non-numeric = FAIL) |
+| `4e00ee6` | #48 | `run --separate-stderr` → `$stderr`; `assert_success` / `assert_failure [code]` |
+| `1cf54a8` | #47 | README: PTYSession section (API table, conftest.py line consumers need) |
+| `38c99b3` | #51 | `pty_run.py --expect TEXT` per-key checkpoint (exit 65; 64 on missing arg) |
+| `0bdb59b` | #50 | `Screen.text()`, `PTYSession.assert_snapshot()`, `pty_snapshot.py` CLI |
+
+**Decisions made:**
+- `$stderr` is populated only with `--separate-stderr` (bats convention) — splitting one run would lose stdout/stderr interleaving that existing `$output` assertions may rely on.
+- In-process function-mock bodies are the default, not opt-in: no consumer repo uses heredoc bodies (grepped shellframe/shellql/seed), so there is no downstream break. Bodies must use `return`, not `exit`.
+- coverage on bash 3.2: documented limitation + hard refusal, not a stderr-redirect fallback — that fallback would push PS4 lines into `run()`'s `$output`.
+- `run.sh --update-snapshots` flag **not** added; `PTYUNIT_UPDATE_SNAPSHOTS=1` env var is the documented path (keeps run.sh untouched).
+
+**Next steps (PM to schedule; worker can execute 1–3 on request):**
+1. Merge `hardening/review-2026-08` → `main` and push. Then close #39–#52 (commit messages reference but do not auto-close).
+2. Docker matrix (`bash tests/docker/run-matrix.sh` or CI on push) — everything was verified on macOS bash 3.2 + 5.x locally; Alpine busybox `awk` (#52) and `read -a` (#49) on 4.4 are the two things worth watching.
+3. Release: features added → **v1.6.0** (`bash release.sh minor`; CHANGELOG is git-cliff-generated). Then bump the Homebrew tap — consumers (shellframe, shellql, seed) install via Homebrew, so no submodule bumps.
+4. Follow-up candidates (not filed): `run.sh` could export `PYTHONPATH=$PTYUNIT_HOME` for pytest so consumers don't need the conftest.py line (#47 documents the workaround); `PTYSession.stdout` still uses bare `ANSI_RE` rather than `strip_ansi()` (kept for backward-compat — it does not normalize `\r\n`).
+
+**Previous state (session 29):** All hardening-complete issues (#36–#38) closed. v1.5.3 released. No open tickets.
 
 **Completed this session (session 29):**
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -37,7 +37,7 @@ independent layers that work together or standalone:
    `--fail-fast`, `--format tap|junit|pretty`, `--jobs N`, `--debug`, `-h`/`--help`.
 
 5. **Code coverage** (`coverage.sh` + `coverage_report.py`) — PS4-based line tracing,
-   text/json/html reports, `--min=N` CI gate. Works on bash 3.2.
+   text/json/html reports, `--min=N` CI gate. Needs bash 4.1+ on PATH (BASH_XTRACEFD); tests themselves still run on 3.2.
 
 6. **Docker cross-version matrix** (`docker/`) — bash 3.2, 4.4, 5.x on Alpine.
 
@@ -49,7 +49,7 @@ independent layers that work together or standalone:
 
 ## Current state
 
-**Self-tests:** 662/662 assertions across 32 files (647 bash + 15 Python). v1.5.1 current.
+**Self-tests:** 724/724 unit + 37/37 integration assertions across 38 files. v1.5.4 current (v1.6.0 pending on `hardening/review-2026-08`).
 
 **Core files:**
 
@@ -125,7 +125,7 @@ blockers.
 |---|---------|--------|--------|
 | 12 | Per-test coverage capture: run each test file individually; emit per-test coverage sets | M | todo |
 | 14 | Redundancy detection: compare per-test coverage sets; report subset tests | L | todo |
-| — | `run` helper: capture stdout+stderr+exit in one call like bats | S | todo |
+| — | `run` helper: capture stdout+stderr+exit in one call like bats | S | done (+ `--separate-stderr`, `assert_success/failure` in #48) |
 | — | `assert_line` negative indices (-1 = last line) | XS | todo |
 | — | `refute_output`, `refute_line` semantic inverses | XS | todo |
 | — | CI workflow (GitHub Actions) for ptyunit itself | S | todo |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ out=$(python3 tests/ptyunit/pty_run.py my_menu.sh DOWN DOWN ENTER)
 assert_contains "$out" "You selected: cherry"
 ```
 
-> **How it works:** `pty_run.py` runs your script inside a real pseudoterminal (PTY), sends keystrokes like `UP`, `DOWN`, `ENTER`, `ESC`, strips all ANSI escape codes, and returns clean text. It supports any program that renders to a terminal — shellframe, dialog, fzf, whiptail, or your own.
+> **How it works:** `pty_run.py` runs your script inside a real pseudoterminal (PTY), sends keystrokes like `UP`, `DOWN`, `ENTER`, `ESC`, strips all ANSI escape codes, and returns clean text. The argument is run as a **bash script** (`bash <script>` — shebangs are not consulted), so anything a bash script can launch is testable: shellframe, dialog, fzf, whiptail, or your own. To drive a non-bash program directly, wrap it: `printf 'exec fzf "$@"\n' > wrap.sh`.
 
 ### Mock external commands
 
@@ -483,9 +483,9 @@ Single characters (`a`, `q`, `1`) and hex escapes (`\x1b`) also work.
 |----------|---------|-----------------|
 | `PTY_COLS` | 80 | Terminal width |
 | `PTY_ROWS` | 24 | Terminal height |
-| `PTY_DELAY` | 0.15 | Seconds between keystrokes |
-| `PTY_INIT` | 0.30 | Seconds before first keystroke (let the UI render) |
+| `PTY_DELAY` | 0.15 | Max seconds to wait for output to settle after each keystroke |
 | `PTY_TIMEOUT` | 10 | Max seconds to wait for the script to exit |
+| `PTY_INIT` | — | **Ignored since v1.5.2** (accepted for compatibility). The first keystroke is sent once the initial render has been quiet for 50 ms, bounded by `PTY_TIMEOUT`. |
 
 > **Exit codes:** The script's own exit code is returned. 124 means timeout (matching GNU `timeout`).
 
@@ -648,7 +648,7 @@ The main differentiator is PTY testing — if your scripts render to `/dev/tty` 
 |---|---|
 | **Bash** | 3.2, 4.x, 5.x |
 | **Python** | 3.6+ (for PTY driver and coverage reports) |
-| **OS** | Linux, macOS |
+| **OS** | Linux, macOS. Windows via WSL only — `pty.fork()` and `/dev/tty` are POSIX; Git Bash, MSYS2, Cygwin and ConPTY are not supported |
 | **Dependencies** | None |
 
 ---

--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ Each row becomes its own test section. Fields are split on `|` and passed as `$1
 
 > **Details:** Lines starting with `#` are skipped (comments). Empty lines are skipped. If any row's callback fails an assertion, it's reported against that specific row.
 
+> **Separator rules:** splitting is on a single character with no escaping, so a value cannot contain the separator. When values need pipes (JSON, `sed` programs, regex alternations), pick another separator with `--sep`:
+>
+> ```bash
+> test_each --sep $'\t' _verify_json << 'PARAMS'
+> {"a":1}	1
+> {"a":[1,2]}	2
+> PARAMS
+> ```
+>
+> A trailing empty field is dropped (`a|b|` yields two params), so put a placeholder in a row whose last value is empty.
+
 ### Group tests with describe blocks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -577,6 +577,28 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "ptyunit"))
 
 > **Which one?** `pty_run.py` when "send keys, check the final text" is enough and you want to stay in bash. `PTYSession` when the assertion is about the rendered screen mid-sequence. Both use the same output-stable waiting, so neither needs sleeps.
 
+### Snapshot the whole screen
+
+For visual regression, compare the rendered screen against a stored fixture instead of asserting row by row:
+
+```python
+def test_main_menu_layout():
+    with PTYSession("my_menu.sh") as s:
+        s.send("DOWN")
+        s.assert_snapshot("main-menu-second-item")
+```
+
+From bash, the same thing without writing Python:
+
+```bash
+test_that "main menu renders"
+assert_true python3 tests/ptyunit/pty_snapshot.py my_menu.sh main-menu DOWN
+```
+
+- The fixture is `__snapshots__/<name>.txt` — beside the calling test file in Python, or `./__snapshots__/` (override with `PTYUNIT_SNAPSHOT_DIR`) from bash. It holds `Screen.text()`: rows right-stripped, trailing blank rows dropped. Commit these files.
+- **First run** writes the fixture and passes (a notice goes to stderr). **Mismatch** fails with a unified diff — fixture on `-`, live screen on `+`.
+- **Accepting a change:** `PTYUNIT_UPDATE_SNAPSHOTS=1 bash tests/ptyunit/run.sh`, or `pty_snapshot.py --update …` / `assert_snapshot(name, update=True)` for one fixture. Review the diff in `git` before committing.
+
 ---
 
 ## Code coverage

--- a/README.md
+++ b/README.md
@@ -504,6 +504,15 @@ Runs `bash <script>` inside a real pseudoterminal, sends each KEY as a keystroke
 
 Single characters (`a`, `q`, `1`) and hex escapes (`\x1b`) also work.
 
+**Checkpoints mid-sequence:** `--expect TEXT` between keys asserts that `TEXT` appears in the output so far *before* the next key is sent. On a miss the remaining keys are skipped, the script is terminated, the exit code is 65 and stderr names the failing checkpoint:
+
+```bash
+out=$(python3 tests/ptyunit/pty_run.py my_menu.sh DOWN --expect "> banana" ENTER)
+assert_eq "0" "$?"
+```
+
+This is the bash-only middle ground between fire-and-forget keys and `PTYSession` (below); it checks the text stream, not screen coordinates.
+
 ### Tuning
 
 | Variable | Default | What it controls |

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ if (( count == 0 )); then
 fi
 ```
 
-> **How it works:** Each test file runs with `set -x` and a custom `PS4` that logs `file:line` to a trace file. A Python script then cross-references the trace against your source files. Works on bash 3.2 — no special tools needed.
+> **How it works:** Each test file runs with `set -x` and a custom `PS4` that logs `file:line` to a trace file via `BASH_XTRACEFD`. A Python script then cross-references the trace against your source files. No special tools needed — but **coverage requires bash 4.1+ on `PATH`** (`BASH_XTRACEFD` doesn't exist on macOS's stock 3.2; `brew install bash`). `coverage.sh` exits 2 with a message on older bash rather than reporting 0%. Your tests still run on 3.2 via `run.sh` — only measurement needs 4.1.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -523,6 +523,51 @@ from pty_run import run
 output, exit_code = run("my_menu.sh", ["DOWN", "ENTER"], key_delay=0.1)
 ```
 
+### Assert on the rendered screen between keystrokes (`PTYSession`)
+
+`pty_run.py` is fire-and-forget: send keys, check the final text. When the assertion is about what's *rendered* after each key — which row is highlighted, what a cell contains — use `PTYSession`. It runs the script under a [pyte](https://github.com/selectel/pyte) terminal emulator and gives you the screen as a grid.
+
+```bash
+pip install -r tests/ptyunit/requirements-screen.txt   # pyte
+```
+
+```python
+# tests/integration/test_menu.py
+from pty_session import PTYSession
+
+def test_down_moves_highlight():
+    with PTYSession("my_menu.sh", cols=80, rows=24) as s:
+        assert s.screen.find_row("> apple") == 2
+        s.send("DOWN")
+        assert s.screen.find_row("> banana") == 3
+        s.send("ENTER")
+        assert s.exit_code == 0
+        assert "You selected: banana" in s.stdout
+```
+
+`send()` writes the key, waits until the screen has been quiet for `stable_window` seconds (default 0.05, bounded by `timeout`), and records the exit code if the script ended on that key.
+
+| | |
+|---|---|
+| `PTYSession(script, *, cols=80, rows=24, timeout=10.0, stable_window=0.05, env=None)` | Context manager. `env` is merged over the inherited environment. |
+| `session.send(key)` | Send one key (same names as `pty_run.py`), then wait for stability |
+| `session.wait_for_stable(window=None)` | Wait without sending — e.g. after a timer-driven redraw |
+| `session.screen` | The current `Screen` |
+| `session.exit_code` | Exit code, or `None` while the script is still running |
+| `session.stdout` | ANSI-stripped output so far |
+| `Screen.row(n)` | Text of row `n` (0-indexed), trailing spaces stripped |
+| `Screen.find_row(text)` | Index of the first row containing `text`, or `None` |
+| `Screen.cell(row, col)` / `Screen.cell_bold(row, col)` | One character / its bold flag at grid coordinates |
+
+Put `test_*.py` files in `tests/unit/` or `tests/integration/` — `run.sh` discovers them and runs each with `pytest`, counting results alongside the bash files. Add a `tests/conftest.py` so the import resolves from your repo:
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "ptyunit"))
+```
+
+> **Which one?** `pty_run.py` when "send keys, check the final text" is enough and you want to stay in bash. `PTYSession` when the assertion is about the rendered screen mid-sequence. Both use the same output-stable waiting, so neither needs sleeps.
+
 ---
 
 ## Code coverage

--- a/README.md
+++ b/README.md
@@ -459,7 +459,15 @@ assert_ge "$count" 1                    # count >= 1
 assert_le "$count" 99                   # count <= 99
 ```
 
-> **These are integer comparisons** using bash arithmetic. They don't handle floats.
+> **These are integer comparisons** using bash arithmetic. For floats use the `assert_float_*` family:
+
+```bash
+assert_float_eq "$ratio" 0.3            # |ratio - 0.3| <= 1e-9
+assert_float_eq "$ratio" 0.3 0.01       # custom tolerance
+assert_float_gt "$elapsed" 1.5          # also _lt, _ge, _le
+```
+
+> Accepts decimal and scientific notation (`1e-3`, `-2.5`, `.25`). Compared with `awk`, so no `bc` needed. Non-numeric input is reported as a failure — never a silent pass.
 
 ### Mocks
 

--- a/README.md
+++ b/README.md
@@ -242,12 +242,20 @@ deploy_to_staging() { echo "deployed to staging"; }
 
 test_that "deploy succeeds"
 run deploy_to_staging
-assert_eq "0" "$status"
+assert_success
 assert_contains "$output" "deployed"
 assert_eq "deployed to staging" "${lines[0]}"
+
+test_that "deploy reports a bad token"
+run --separate-stderr deploy_to_staging --token bad
+assert_failure 2                 # or plain assert_failure for "any non-zero"
+assert_eq "" "$output"           # nothing on stdout…
+assert_contains "$stderr" "401"  # …the error went to stderr
 ```
 
-`run` captures everything at once: `$output` (stdout+stderr), `$status` (exit code), and `$lines` (array, one element per line).
+`run` captures everything at once: `$output` (stdout+stderr), `$status` (exit code), and `$lines` (array, one element per line). `assert_success` / `assert_failure [code]` check `$status` and print the captured output on failure.
+
+With `--separate-stderr`, `$output` holds only stdout and `$stderr` holds stderr. Without it, `$output` keeps both streams interleaved in the order they appeared and `$stderr` is empty — splitting can't preserve interleaving, so it's opt-in.
 
 > **Why this helps:** Without `run`, you'd write `out=$(cmd 2>&1); rc=$?` and manually split lines. With `run`, it's one call. The `$lines` array lets you check specific lines by index: `${lines[0]}` is the first line, `${lines[1]}` the second, etc.
 

--- a/assert.sh
+++ b/assert.sh
@@ -176,14 +176,29 @@ end_describe() {
 # A test_that section is created for each row, named after the callback
 # and the raw parameter line.
 # Lines starting with # are skipped.
+#
+# Fields are split on a single character (default `|`) with no escaping —
+# a value cannot contain the separator. For values with pipes (JSON, sed
+# programs, regexes) pick another separator: `--sep $'\t'` or `--sep ,`.
+# A trailing empty field is dropped (`a|b|` → 2 params), so a row whose
+# last value is empty needs a placeholder.
 
 test_each() {
+    local _ptyunit_sep='|'
+    if [[ "${1:-}" == "--sep" ]]; then
+        _ptyunit_sep="${2:-}"
+        if (( ${#_ptyunit_sep} != 1 )); then
+            printf 'test_each: --sep must be a single character, got %q\n' "$_ptyunit_sep" >&2
+            return 2
+        fi
+        shift 2
+    fi
     local callback="$1"
     local _ptyunit_pline
     while IFS= read -r _ptyunit_pline || [[ -n "$_ptyunit_pline" ]]; do
         [[ -z "$_ptyunit_pline" || "$_ptyunit_pline" == \#* ]] && continue
         local _ptyunit_params=()
-        IFS='|' read -ra _ptyunit_params <<< "$_ptyunit_pline"
+        IFS="$_ptyunit_sep" read -ra _ptyunit_params <<< "$_ptyunit_pline"
         ptyunit_test_begin "$callback (${_ptyunit_pline})"
         "$callback" "${_ptyunit_params[@]}"
     done
@@ -462,6 +477,54 @@ assert_le() {
         _ptyunit_report_fail "$msg" "$(printf '  expected: %s <= %s' "$actual" "$threshold")"
     fi
 }
+
+# ── Float comparisons ────────────────────────────────────────────────────────
+# Decimal or scientific notation (1.5, -2, .25, 1e-3). Compared with awk
+# (POSIX — no bc needed). Non-numeric input is a FAIL, never a silent pass.
+#
+# Usage:
+#   assert_float_eq actual expected [tolerance=1e-9] [msg]
+#   assert_float_gt actual threshold [msg]     (also _lt, _ge, _le)
+
+_ptyunit_is_number() {
+    [[ "$1" =~ ^[-+]?([0-9]+\.?[0-9]*|\.[0-9]+)([eE][-+]?[0-9]+)?$ ]]
+}
+
+# Shared driver: _ptyunit_float_assert <op> <a> <b> <tol> <msg> <symbol>
+_ptyunit_float_assert() {
+    (( _PTYUNIT_SKIP_CURRENT )) && return
+    local op="$1" a="$2" b="$3" tol="$4" msg="$5" sym="$6"
+    local _x
+    for _x in "$a" "$b" "$tol"; do
+        if ! _ptyunit_is_number "$_x"; then
+            # @pty_skip
+            _ptyunit_report_fail "$msg" "$(printf '  not a number: %q' "$_x")"
+            return
+        fi
+    done
+    if awk -v a="$a" -v b="$b" -v t="$tol" -v op="$op" 'BEGIN {
+            a += 0; b += 0; t += 0
+            if      (op == "eq") ok = (a - b <= t && b - a <= t)
+            else if (op == "gt") ok = (a > b)
+            else if (op == "lt") ok = (a < b)
+            else if (op == "ge") ok = (a >= b)
+            else                 ok = (a <= b)
+            exit !ok }'; then
+        (( _PTYUNIT_TEST_PASS++ )) || true
+    else
+        # @pty_skip
+        _ptyunit_report_fail "$msg" "$(printf '  expected: %s %s %s' "$a" "$sym" "$b")"
+    fi
+}
+
+assert_float_eq() {
+    local tol="${3:-1e-9}"
+    _ptyunit_float_assert eq "$1" "$2" "$tol" "${4:-}" "≈ (±$tol)"
+}
+assert_float_gt() { _ptyunit_float_assert gt "$1" "$2" 0 "${3:-}" ">";  }
+assert_float_lt() { _ptyunit_float_assert lt "$1" "$2" 0 "${3:-}" "<";  }
+assert_float_ge() { _ptyunit_float_assert ge "$1" "$2" 0 "${3:-}" ">="; }
+assert_float_le() { _ptyunit_float_assert le "$1" "$2" 0 "${3:-}" "<="; }
 
 # ── run helper ───────────────────────────────────────────────────────────────
 # Capture a command's stdout+stderr and exit code in one call.

--- a/assert.sh
+++ b/assert.sh
@@ -527,24 +527,88 @@ assert_float_ge() { _ptyunit_float_assert ge "$1" "$2" 0 "${3:-}" ">="; }
 assert_float_le() { _ptyunit_float_assert le "$1" "$2" 0 "${3:-}" "<="; }
 
 # ── run helper ───────────────────────────────────────────────────────────────
-# Capture a command's stdout+stderr and exit code in one call.
-# Sets: $output (string), $status (integer), $lines (array).
+# Capture a command's output and exit code in one call.
+# Sets: $output (string), $status (integer), $lines (array), $stderr (string).
 #
 # Usage:
 #   run my_command arg1 arg2
-#   assert_eq "0" "$status"
+#   assert_success                        # or: assert_eq "0" "$status"
 #   assert_contains "$output" "success"
 #   assert_eq "first line" "${lines[0]}"
+#
+#   run --separate-stderr my_command      # $output = stdout only
+#   assert_eq "" "$stderr"                # $stderr = stderr only
+#
+# Without --separate-stderr, $output holds both streams interleaved (as a
+# terminal would show them) and $stderr is "". Splitting one run into two
+# variables would lose that interleaving, so it is opt-in (#48).
 
 run() {
-    local _rc=0
-    output=$("$@" 2>&1) || _rc=$?
+    local _rc=0 _ptyunit_separate=0
+    if [[ "${1:-}" == "--separate-stderr" ]]; then
+        _ptyunit_separate=1
+        shift
+    fi
+    stderr=""
+    if (( _ptyunit_separate )); then
+        local _ptyunit_errf
+        _ptyunit_errf=$(mktemp "${TMPDIR:-/tmp}/ptyunit-run.XXXXXX") || {
+            # @pty_skip — mktemp failure; infrastructure error path
+            printf 'ptyunit: run: mktemp failed\n' >&2
+            return 1
+        }
+        output=$("$@" 2>"$_ptyunit_errf") || _rc=$?
+        stderr=$(<"$_ptyunit_errf")
+        rm -f "$_ptyunit_errf"
+    else
+        output=$("$@" 2>&1) || _rc=$?
+    fi
     status=$_rc
     lines=()
     if [[ -n "$output" ]]; then
         while IFS= read -r _ptyunit_run_line; do
             lines+=("$_ptyunit_run_line")
         done <<< "$output"
+    fi
+}
+
+# ── Exit-status assertions (use after `run`) ─────────────────────────────────
+# assert_success [msg]              — $status is 0
+# assert_failure [expected] [msg]   — $status is non-zero, or equals expected
+
+assert_success() {
+    (( _PTYUNIT_SKIP_CURRENT )) && return
+    local msg="${1:-}"
+    if [[ "${status:-}" == "0" ]]; then
+        (( _PTYUNIT_TEST_PASS++ )) || true
+    else
+        # @pty_skip
+        _ptyunit_report_fail "$msg" "$(printf '  expected status 0, got status %s\n  output: %s' \
+            "${status:-unset}" "${output:-}")"
+    fi
+}
+
+assert_failure() {
+    (( _PTYUNIT_SKIP_CURRENT )) && return
+    local expected="" msg=""
+    if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+        expected="$1"; msg="${2:-}"
+    else
+        msg="${1:-}"
+    fi
+    if [[ -z "$expected" ]]; then
+        if [[ "${status:-0}" != "0" ]]; then
+            (( _PTYUNIT_TEST_PASS++ )) || true
+        else
+            # @pty_skip
+            _ptyunit_report_fail "$msg" "$(printf '  expected non-zero status, got status 0\n  output: %s' "${output:-}")"
+        fi
+    elif [[ "${status:-}" == "$expected" ]]; then
+        (( _PTYUNIT_TEST_PASS++ )) || true
+    else
+        # @pty_skip
+        _ptyunit_report_fail "$msg" "$(printf '  expected status %s, got status %s\n  output: %s' \
+            "$expected" "${status:-unset}" "${output:-}")"
     fi
 }
 

--- a/assert.sh
+++ b/assert.sh
@@ -167,7 +167,7 @@ end_describe() {
 # Run a callback once per line from stdin. Fields are split on |.
 #
 # Usage:
-#   test_each <callback> << 'PARAMS'
+#   test_each [--sep CHAR] <callback> << 'PARAMS'
 #   input1|input2|expected
 #   input3|input4|expected
 #   PARAMS

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # ptyunit/coverage.sh — Bash code coverage via PS4 trace
 #
-# COMPATIBILITY: bash 3.2+ (macOS default).
+# COMPATIBILITY: this script runs on bash 3.2+, but tracing requires the
+# `bash` on PATH to be 4.1+ (BASH_XTRACEFD). On macOS: brew install bash.
+# The tests themselves still run on 3.2 via run.sh — only coverage needs 4.1.
 #
 # ── Usage ─────────────────────────────────────────────────────────────────────
 #
@@ -17,9 +19,13 @@
 # ── How it works ──────────────────────────────────────────────────────────────
 #
 # Runs each test file with set -x and a custom PS4 that logs file:line.
-# On bash 3.2 (macOS), BASH_XTRACEFD is not available, so xtrace goes to
-# stderr. The wrapper redirects stderr to the trace file and captures
-# stdout for test results.
+# Traces go to the trace file via BASH_XTRACEFD (fd 3) so they stay off
+# stderr — otherwise assert.sh's run() helper (2>&1) would capture PS4 lines
+# into $output. stderr is discarded; stdout is captured for test results.
+#
+# BASH_XTRACEFD does not exist before bash 4.1: older bash ignores it and
+# sends xtrace to the discarded stderr, so the trace file would stay empty
+# and every file would report 0%. We refuse to run in that case (#43).
 
 set -u
 
@@ -35,6 +41,17 @@ if [[ ! -f "$PTYUNIT_HOME/assert.sh" ]]; then
     exit 1
 fi
 export PTYUNIT_HOME
+
+# ── Require bash 4.1+ on PATH for tracing ────────────────────────────────────
+# Check the `bash` the wrapper below will invoke, not the one running this file.
+
+_cov_bash_ver=$(bash -c 'printf "%s%02d" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"' 2>/dev/null || echo 0)
+if (( 10#$_cov_bash_ver < 401 )); then
+    printf 'coverage: requires bash 4.1+ on PATH (BASH_XTRACEFD) — found %s at %s\n' \
+        "$(bash -c 'printf "%s" "$BASH_VERSION"' 2>/dev/null)" "$(command -v bash)" >&2
+    printf 'coverage: on macOS run "brew install bash"; tests themselves still run on bash 3.2 via run.sh\n' >&2
+    exit 2
+fi
 
 # ── Parse arguments ──────────────────────────────────────────────────────────
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -106,6 +106,8 @@ Literal characters (`y`, `q`, `1`) and hex escapes (`\x1b`) are also accepted.
 
 `PTY_INIT` is accepted but ignored: the first key is sent when the initial render has been quiet for 50 ms, so slow-starting scripts no longer need tuning.
 
+To assert on the *rendered screen* between keystrokes (which row is highlighted, what a cell contains) rather than on the final text, use `PTYSession` from `pty_session.py` — see "Assert on the rendered screen between keystrokes" in the README.
+
 ---
 
 ## Running tests

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -101,9 +101,10 @@ Literal characters (`y`, `q`, `1`) and hex escapes (`\x1b`) are also accepted.
 
 | Variable | Default | When to change |
 |----------|---------|----------------|
-| `PTY_INIT` | `0.30` | Slow-starting scripts need more init time |
-| `PTY_DELAY` | `0.15` | Slow keystroke processing needs larger delay |
-| `PTY_TIMEOUT` | `10` | Long-running scripts need more timeout |
+| `PTY_DELAY` | `0.15` | Slow keystroke processing needs a larger settle window |
+| `PTY_TIMEOUT` | `10` | Long-running or slow-starting scripts need more timeout (also bounds the wait for the initial render) |
+
+`PTY_INIT` is accepted but ignored: the first key is sent when the initial render has been quiet for 50 ms, so slow-starting scripts no longer need tuning.
 
 ---
 

--- a/help.sh
+++ b/help.sh
@@ -164,7 +164,9 @@ _help_params() {
     printf '  PARAMS\n\n'
     printf 'Fields are split on | and passed as $1 $2 $3 ... to the callback.\n'
     printf 'Each row is an independent test section. A failing row does not stop\n'
-    printf 'the others. Lines starting with # are skipped.\n'
+    printf 'the others. Lines starting with # are skipped.\n\n'
+    printf 'Values cannot contain the separator (no escaping). Pick another one\n'
+    printf "with --sep when values need pipes:  test_each --sep \$'\\\\t' _cb << 'P'\n"
 }
 
 _help_describe() {

--- a/mock.sh
+++ b/mock.sh
@@ -13,9 +13,17 @@
 # test_they). No manual cleanup needed.
 #
 # Auto-detection: if <name> is a currently defined function, creates a
-# function mock (in-process). Otherwise creates a command mock (PATH-based
-# executable script). Command mocks work across subshells and with
-# `command <name>`.
+# function mock. Otherwise creates a command mock (PATH-based executable
+# script). Command mocks work across subshells and with `command <name>`.
+#
+# Where the heredoc BODY runs — this differs by mock type:
+#   function mock  — in the current process (sourced inside a function):
+#                    it can call your other functions, read and set globals,
+#                    use `local`, and must use `return N` (not `exit`) to set
+#                    its status — `exit` would end the test process.
+#   command mock   — in a separate bash process (it is an executable): it sees
+#                    only exported variables, cannot mutate caller state, and
+#                    uses `exit N`.
 #
 # Verification assertions:
 #   assert_called <name>                 — called at least once
@@ -159,6 +167,14 @@ MOCKSCRIPT
 
 # ── Function mock dispatcher (runs in-process) ─────────────────────────────
 
+# Run a heredoc body in the current process with "$@" as its positional
+# parameters. Wrapping the source in a function gives the body a function
+# context, so `local` and `return` work at its top level (#41).
+_ptyunit_mock_run_body() {
+    local _ptyunit_body_file="$1"; shift
+    source "$_ptyunit_body_file" "$@"
+}
+
 _ptyunit_mock_dispatch() {
     local _mock_name="$1"; shift
     local _state="$_PTYUNIT_MOCK_DIR/state/$_mock_name"
@@ -169,7 +185,7 @@ _ptyunit_mock_dispatch() {
     printf '%s\0' "$@" > "$_state.args.$_n"
     export MOCK_CALL_NUM="$_n"
     if [[ -f "$_state.body" ]]; then
-        bash "$_state.body" "$@"
+        _ptyunit_mock_run_body "$_state.body" "$@"
         return $?
     elif [[ -f "$_state.output" ]]; then
         cat "$_state.output"

--- a/mock.sh
+++ b/mock.sh
@@ -49,7 +49,6 @@ _ptyunit_mock_init() {
             _PTYUNIT_MOCK_DIR=""
             return 1
         }
-        printf '%s' "$PATH" > "$_PTYUNIT_MOCK_DIR/original_path"
         PATH="$_PTYUNIT_MOCK_DIR/bin:$PATH"
         export PATH
     fi
@@ -60,6 +59,14 @@ _ptyunit_mock_init() {
 ptyunit_mock() {
     local name="$1"; shift
     local mock_output="" mock_exit="0"
+
+    # Validate the name before it reaches any file path or eval (#40).
+    # Allows identifiers plus '.' and '-' so command names like
+    # docker-compose or foo.sh work; rejects '/', whitespace, metacharacters.
+    if [[ ! "$name" =~ ^[A-Za-z_][A-Za-z0-9_.-]*$ ]]; then
+        printf 'ptyunit_mock: invalid mock name %q\n' "$name" >&2
+        return 2
+    fi
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -94,8 +101,10 @@ ptyunit_mock() {
     fi
     printf '%s' "$mock_type" > "$state_dir/$name.type"
 
-    # Register the mock
-    printf '%s\n' "$name" >> "$_PTYUNIT_MOCK_DIR/registry"
+    # Register the mock (once — re-mocking must not add a duplicate entry, #39)
+    if ! grep -qx -- "$name" "$_PTYUNIT_MOCK_DIR/registry" 2>/dev/null; then
+        printf '%s\n' "$name" >> "$_PTYUNIT_MOCK_DIR/registry"
+    fi
 
     if [[ "$mock_type" == "function" ]]; then
         _ptyunit_mock_create_function "$name" "$state_dir"
@@ -109,8 +118,12 @@ ptyunit_mock() {
 _ptyunit_mock_create_function() {
     local name="$1" state_dir="$2"
 
-    # Save original function definition
-    declare -f "$name" > "$_PTYUNIT_MOCK_DIR/_origfunc_$name" 2>/dev/null || true
+    # Save original function definition — only on the first mock of this name.
+    # Re-mocking within a section would otherwise capture mock #1's dispatcher
+    # as the "original" and leak it into every later section (#39).
+    if [[ ! -f "$_PTYUNIT_MOCK_DIR/_origfunc_$name" ]]; then
+        declare -f "$name" > "$_PTYUNIT_MOCK_DIR/_origfunc_$name" 2>/dev/null || true
+    fi
 
     # Create mock function that dispatches to _ptyunit_mock_dispatch
     eval "${name}() { _ptyunit_mock_dispatch '${name}' \"\$@\"; }"
@@ -177,9 +190,11 @@ ptyunit_unmock() {
 
     if [[ "$mock_type" == "function" ]]; then
         unset -f "$name" 2>/dev/null
-        # Restore original function if it was saved
+        # Restore original function if it was saved, then forget it so a
+        # later mock of the same name captures a fresh original.
         if [[ -f "$_PTYUNIT_MOCK_DIR/_origfunc_$name" ]]; then
             source "$_PTYUNIT_MOCK_DIR/_origfunc_$name"
+            rm -f "$_PTYUNIT_MOCK_DIR/_origfunc_$name"
         fi
     else
         rm -f "$_PTYUNIT_MOCK_DIR/bin/$name"
@@ -201,15 +216,14 @@ _ptyunit_mock_cleanup_all() {
         done < "$_PTYUNIT_MOCK_DIR/registry"  # @pty_skip
     fi
 
-    # Restore original PATH
-    if [[ -f "$_PTYUNIT_MOCK_DIR/original_path" ]]; then
-        local _saved_path
-        _saved_path=$(<"$_PTYUNIT_MOCK_DIR/original_path")
-        if [[ -n "$_saved_path" ]]; then
-            PATH="$_saved_path"
-            export PATH
-        fi
-    fi
+    # Remove only the mock bin dir from PATH. Restoring a snapshot would
+    # clobber PATH changes the test itself made after mocking (#42).
+    local _mock_bin="$_PTYUNIT_MOCK_DIR/bin"
+    PATH=":$PATH:"
+    PATH="${PATH//":$_mock_bin:"/:}"
+    PATH="${PATH#:}"
+    PATH="${PATH%:}"
+    export PATH
 
     [[ -n "$_PTYUNIT_MOCK_DIR" ]] && rm -rf "$_PTYUNIT_MOCK_DIR"
     _PTYUNIT_MOCK_DIR=""

--- a/pty_run.py
+++ b/pty_run.py
@@ -14,6 +14,13 @@ Keys:
     PAGE_UP PAGE_DOWN                     paging keys
     q, a, v, ...                          literal single characters
     \\x1b, \\r, \\n, ...                  hex escape sequences
+    --expect TEXT                         checkpoint: after the preceding key
+                                          settles, the stripped output so far
+                                          must contain TEXT; otherwise no more
+                                          keys are sent, the child is killed,
+                                          exit code is 65 and a diagnostic goes
+                                          to stderr. Before any key it checks
+                                          the initial render.
 
 Options (set via env vars):
     PTY_COLS=80     terminal width  (default: 80)
@@ -214,8 +221,32 @@ def run(
 ) -> tuple:
     """Run *script* in a PTY with proper controlling terminal.
 
+    *keys* items are key tokens (see module docstring) or ``("expect", text)``
+    checkpoints: after the preceding key's output settles, *text* must appear
+    in the cumulative stripped output. On a miss the remaining keys are not
+    sent, the child is terminated, a diagnostic is written to stderr, and the
+    exit code is 65 (EX_DATAERR).
+
     Returns (stripped_output, exit_code).
     """
+    EX_DATAERR = 65
+
+    def _render(buf: bytes) -> str:
+        if raw:
+            return buf.replace(b"\r\n", b"\n").replace(b"\r", b"\n").decode("utf-8", errors="replace")
+        return strip_ansi(buf).decode("utf-8", errors="replace")
+
+    def _terminate(pid: int) -> None:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            time.sleep(0.2)
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
     # If coverage instrumentation is requested, write a BASH_ENV startup script
     # that enables PS4 xtrace to the shared trace file before the child runs.
     # BASH_ENV is sourced by bash for every non-interactive shell invocation
@@ -262,23 +293,42 @@ def run(
         output += _drain_until_stable(master, timeout=timeout)
 
         # Send keystrokes one at a time
+        exit_code = None
+        last_key = None
+        key_index = 0
         for key in keys:
+            if isinstance(key, tuple) and key[0] == "expect":
+                expected = key[1]
+                if expected not in _render(output):
+                    after = f"after key #{key_index} ({last_key!r})" if last_key is not None \
+                        else "in the initial render"
+                    tail = "\n".join(_render(output).splitlines()[-10:])
+                    sys.stderr.write(
+                        f"pty_run: --expect {expected!r} not satisfied {after}; "
+                        f"output so far (last lines):\n{tail}\n"
+                    )
+                    _terminate(pid)
+                    exit_code = EX_DATAERR
+                    break
+                continue
             # Check if child already exited
             result = os.waitpid(pid, os.WNOHANG)
             if result[0] != 0:
+                exit_code = os.waitstatus_to_exitcode(result[1])
                 break
             try:
                 os.write(master, parse_key(key))
             except OSError:
                 break
+            last_key = key
+            key_index += 1
             # PTY_DELAY is now the maximum wait per key, not a fixed sleep.
             output += _drain_until_stable(master, timeout=key_delay)
 
         # Wait for the child to exit (up to timeout)
         deadline = time.time() + timeout
-        exit_code = None
 
-        while time.time() < deadline:
+        while exit_code is None and time.time() < deadline:
             result = os.waitpid(pid, os.WNOHANG)
             if result[0] != 0:
                 exit_code = os.waitstatus_to_exitcode(result[1])
@@ -334,7 +384,19 @@ def main():
         sys.exit(1)
 
     script = sys.argv[1]
-    keys = sys.argv[2:]
+    keys = []
+    argv = sys.argv[2:]
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--expect":
+            if i + 1 >= len(argv):
+                sys.stderr.write("pty_run: --expect requires a TEXT argument\n")
+                sys.exit(64)  # EX_USAGE
+            keys.append(("expect", argv[i + 1]))
+            i += 2
+        else:
+            keys.append(argv[i])
+            i += 1
 
     cols     = int(os.environ.get("PTY_COLS",    80))
     rows     = int(os.environ.get("PTY_ROWS",    24))

--- a/pty_run.py
+++ b/pty_run.py
@@ -62,6 +62,7 @@ import tempfile
 import termios
 import time
 
+
 NAMED_KEYS = {
     "UP":        b"\x1b[A",
     "DOWN":      b"\x1b[B",
@@ -207,6 +208,26 @@ def _drain_until_stable(fd: int, window: float = 0.05, timeout: float = 10.0) ->
     return buf
 
 
+def _reap(pid: int, blocking: bool = False, max_wait: float = 5.0):
+    """Reap *pid*, returning its exit code, or None if it has not exited.
+
+    Never raises or blocks indefinitely: ECHILD/ESRCH return None, and
+    blocking=True polls with WNOHANG for at most *max_wait* seconds before
+    giving up, so a wedged child can never hang the runner.
+    """
+    deadline = time.monotonic() + max_wait
+    while True:
+        try:
+            waited, status = os.waitpid(pid, os.WNOHANG)
+        except (ChildProcessError, OSError):
+            return None
+        if waited != 0:
+            return os.waitstatus_to_exitcode(status)
+        if not blocking or time.monotonic() >= deadline:
+            return None
+        time.sleep(0.01)
+
+
 def run(
     script: str,
     keys: list,
@@ -243,10 +264,7 @@ def run(
             os.kill(pid, signal.SIGKILL)
         except OSError:
             pass
-        try:
-            os.waitpid(pid, 0)
-        except OSError:
-            pass
+        _reap(pid, blocking=True)
     # If coverage instrumentation is requested, write a BASH_ENV startup script
     # that enables PS4 xtrace to the shared trace file before the child runs.
     # BASH_ENV is sourced by bash for every non-interactive shell invocation
@@ -273,6 +291,18 @@ def run(
                 pass
             if _bash_env:
                 os.environ["BASH_ENV"] = _bash_env
+            # Restore default signal dispositions before exec. This runner is
+            # frequently invoked from bash asynchronous contexts (test-runner
+            # worker pools), where SIGINT/SIGQUIT are set to SIG_IGN and the
+            # ignore is inherited across fork+exec. POSIX says a shell cannot
+            # trap a signal that was ignored on entry, so without this the
+            # guest TUI could never receive Ctrl-C. Raw sigaction is not
+            # subject to that restriction.
+            for _sig in (signal.SIGINT, signal.SIGQUIT):
+                try:
+                    signal.signal(_sig, signal.SIG_DFL)
+                except (ValueError, OSError, RuntimeError):
+                    pass
             os.execvp("bash", ["bash", script])
             # execvp replaces the process; this line is unreachable
             os._exit(1)
@@ -312,9 +342,8 @@ def run(
                     break
                 continue
             # Check if child already exited
-            result = os.waitpid(pid, os.WNOHANG)
-            if result[0] != 0:
-                exit_code = os.waitstatus_to_exitcode(result[1])
+            exit_code = _reap(pid)
+            if exit_code is not None:
                 break
             try:
                 os.write(master, parse_key(key))
@@ -329,9 +358,8 @@ def run(
         deadline = time.time() + timeout
 
         while exit_code is None and time.time() < deadline:
-            result = os.waitpid(pid, os.WNOHANG)
-            if result[0] != 0:
-                exit_code = os.waitstatus_to_exitcode(result[1])
+            exit_code = _reap(pid)
+            if exit_code is not None:
                 break
             r, _, _ = select.select([master], [], [], 0.1)
             if r:
@@ -340,19 +368,20 @@ def run(
                     output += chunk
                 except OSError:
                     # Child closed the slave (exited)
-                    result = os.waitpid(pid, 0)
-                    exit_code = os.waitstatus_to_exitcode(result[1])
+                    exit_code = _reap(pid, blocking=True)
                     break
 
         if exit_code is None:
-            # Timeout — kill the child
+            # Timeout — kill the child. A kill raising ESRCH (died between
+            # checks) or the reap racing a prior reap must never wedge the
+            # runner: fall through to the bounded 124 regardless.
             try:
                 os.kill(pid, signal.SIGTERM)
                 time.sleep(0.5)
                 os.kill(pid, signal.SIGKILL)
             except OSError:
                 pass
-            os.waitpid(pid, 0)
+            _reap(pid, blocking=True)
             exit_code = 124  # conventional timeout exit code
 
         # Final drain

--- a/pty_run.py
+++ b/pty_run.py
@@ -84,6 +84,27 @@ ANSI_RE = re.compile(
 )
 
 
+# A child killed mid-sequence (timeout) can leave a truncated escape at the
+# very end of the buffer. ANSI_RE needs a final byte and cannot match it, so
+# the raw ESC would leak into "stripped" output (#45). This matches one
+# incomplete CSI / OSC / DCS-family / nF prefix — or a bare ESC — at end of data.
+_TRAILING_PARTIAL_RE = re.compile(
+    rb"\x1b(?:\[[0-?]*[ -/]*|\][^\x07\x1b]*|[PX^_][^\x1b]*|[ -/]*)?$"
+)
+
+
+def strip_ansi(data: bytes) -> bytes:
+    """Remove ANSI escape sequences and normalize line endings to \\n.
+
+    The trailing incomplete sequence must be dropped *before* ANSI_RE runs:
+    for a truncated OSC/DCS (no terminator) the ST-terminated arms fail and
+    the Fe catch-all would strip just `ESC ]` / `ESC P`, leaking the payload.
+    """
+    out = _TRAILING_PARTIAL_RE.sub(b"", data)
+    out = ANSI_RE.sub(b"", out)
+    return out.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
 def coverage_bash_env_script(coverage_file: str) -> str:
     """Return the BASH_ENV startup script that enables PS4 xtrace into
     *coverage_file* on fd 9.
@@ -293,8 +314,7 @@ def run(
         if raw:
             result = output.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
         else:
-            result = ANSI_RE.sub(b"", output)
-            result = result.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+            result = strip_ansi(output)
 
         return result.decode("utf-8", errors="replace"), exit_code
 

--- a/pty_run.py
+++ b/pty_run.py
@@ -18,9 +18,11 @@ Keys:
 Options (set via env vars):
     PTY_COLS=80     terminal width  (default: 80)
     PTY_ROWS=24     terminal height (default: 24)
-    PTY_DELAY=0.15  seconds between keys (default: 0.15)
-    PTY_INIT=0.30   seconds to wait before first key (default: 0.30)
-    PTY_TIMEOUT=10  seconds to wait for process exit (default: 10)
+    PTY_DELAY=0.15  max seconds to wait for output to settle after each key
+    PTY_TIMEOUT=10  seconds to wait for process exit (default: 10); also
+                    bounds the wait for the initial render
+    PTY_INIT        ignored (accepted for compatibility) — the first key is
+                    sent once the initial render has been quiet for 50 ms
     PTY_RAW=0       set to 1 to preserve ANSI escapes in output (default: 0)
                     WARNING: PTY_RAW=1 bypasses all ANSI stripping. Any escape
                     sequences emitted by the child (including OSC title-sets,

--- a/pty_run.py
+++ b/pty_run.py
@@ -84,6 +84,27 @@ ANSI_RE = re.compile(
 )
 
 
+def coverage_bash_env_script(coverage_file: str) -> str:
+    """Return the BASH_ENV startup script that enables PS4 xtrace into
+    *coverage_file* on fd 9.
+
+    Shared by pty_run.run() and pty_session.PTYSession so the two drivers
+    cannot drift (#44). The version guard matters: BASH_XTRACEFD arrived in
+    bash 4.1; on older bash `set -x` writes to stderr — which is the PTY —
+    and trace lines would pollute the captured output. The comparison is
+    (major > 4) or (major == 4 and minor >= 1), so bash 5.0 is included.
+    """
+    return (
+        f'exec 9>>"{coverage_file}"\n'
+        "if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 1) )); then\n"
+        "    export BASH_XTRACEFD=9\n"
+        "    PS4='+${BASH_SOURCE:-?}:${LINENO} '\n"
+        "    export PS4\n"
+        "    set -x\n"
+        "fi\n"
+    )
+
+
 def parse_key(token: str) -> bytes:
     if token in NAMED_KEYS:
         return NAMED_KEYS[token]
@@ -180,13 +201,7 @@ def run(
     if coverage_file:
         fd, _bash_env = tempfile.mkstemp(suffix='.sh')
         with os.fdopen(fd, 'w') as f:
-            f.write(
-                f'exec 9>>"{coverage_file}"\n'
-                'export BASH_XTRACEFD=9\n'
-                "PS4='+${BASH_SOURCE:-?}:${LINENO} '\n"
-                'export PS4\n'
-                'set -x\n'
-            )
+            f.write(coverage_bash_env_script(coverage_file))
 
     try:
         # pty.fork() creates a PTY pair and forks.

--- a/pty_session.py
+++ b/pty_session.py
@@ -15,12 +15,15 @@ Usage:
         assert session.screen.find_row("[ No ]") is not None
 """
 
+import difflib
 import fcntl
+import inspect
 import os
 import pty
 import select
 import signal
 import struct
+import sys
 import tempfile
 import termios
 import time
@@ -62,6 +65,18 @@ class Screen:
             if text in line:
                 return i
         return None
+
+    def text(self) -> str:
+        """The whole screen as one normalized string (#50).
+
+        Rows are right-stripped and joined with newlines; trailing blank rows
+        are dropped so a 24-row terminal showing 3 lines yields 3 lines. This
+        is the form stored by assert_snapshot().
+        """
+        rows = [line.rstrip() for line in self._screen.display]
+        while rows and not rows[-1]:
+            rows.pop()
+        return "\n".join(rows)
 
 
 class PTYSession:
@@ -298,3 +313,49 @@ class PTYSession:
     def stdout(self) -> str:
         """ANSI-stripped accumulated output. Valid at any point (partial mid-session)."""
         return ANSI_RE.sub(b"", self._raw_output).decode("utf-8", errors="replace")
+
+    def assert_snapshot(self, name: str, *, snapshot_dir: str = None,
+                        update: bool = False) -> None:
+        """Compare the current screen against a stored fixture (#50).
+
+        The fixture is ``<snapshot_dir>/<name>.txt`` holding Screen.text()
+        plus a trailing newline. *snapshot_dir* defaults to
+        ``$PTYUNIT_SNAPSHOT_DIR``, else ``__snapshots__/`` beside the calling
+        test file.
+
+        - No fixture yet: it is written, a notice goes to stderr, and the
+          assertion passes (Jest/insta convention).
+        - ``update=True`` or ``PTYUNIT_UPDATE_SNAPSHOTS=1``: the fixture is
+          rewritten unconditionally.
+        - Mismatch: AssertionError whose message is a unified diff
+          (fixture on the ``-`` side, live screen on the ``+`` side).
+        """
+        if snapshot_dir is None:
+            snapshot_dir = os.environ.get("PTYUNIT_SNAPSHOT_DIR")
+        if snapshot_dir is None:
+            caller = inspect.stack()[1].filename
+            snapshot_dir = os.path.join(os.path.dirname(os.path.abspath(caller)), "__snapshots__")
+        update = update or os.environ.get("PTYUNIT_UPDATE_SNAPSHOTS") == "1"
+
+        path = os.path.join(snapshot_dir, f"{name}.txt")
+        actual = self.screen.text() + "\n"
+
+        if update or not os.path.exists(path):
+            verb = "updated" if os.path.exists(path) else "wrote new"
+            os.makedirs(snapshot_dir, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(actual)
+            sys.stderr.write(f"ptyunit: {verb} snapshot {path}\n")
+            return
+
+        with open(path, encoding="utf-8") as f:
+            expected = f.read()
+        if expected != actual:
+            diff = "".join(difflib.unified_diff(
+                expected.splitlines(True), actual.splitlines(True),
+                fromfile=path, tofile="<live screen>",
+            ))
+            raise AssertionError(
+                f"screen snapshot mismatch: {path}\n"
+                f"(rerun with PTYUNIT_UPDATE_SNAPSHOTS=1 to accept the new screen)\n{diff}"
+            )

--- a/pty_session.py
+++ b/pty_session.py
@@ -27,7 +27,7 @@ import time
 
 import pyte
 
-from pty_run import ANSI_RE, NAMED_KEYS, parse_key  # noqa: F401 (re-exported)
+from pty_run import ANSI_RE, NAMED_KEYS, parse_key, coverage_bash_env_script  # noqa: F401 (re-exported)
 
 
 class Screen:
@@ -118,22 +118,14 @@ class PTYSession:
         # Coverage injection: if PTYUNIT_COVERAGE_FILE is set, write a BASH_ENV
         # startup script that enables PS4 xtrace into the trace file.
         # Must happen before fork so the child inherits the updated BASH_ENV.
-        # BASH_XTRACEFD requires bash 4.1+; the guard prevents set -x from
-        # redirecting to stderr (fd 2) on bash 3.2, which would corrupt PTY output.
+        # The script text (with its bash-4.1 BASH_XTRACEFD guard) is shared
+        # with pty_run.run() — see coverage_bash_env_script() there (#44).
         coverage_file = os.environ.get("PTYUNIT_COVERAGE_FILE")
         if coverage_file:
             self._prev_bash_env = os.environ.get("BASH_ENV")
             fd, self._bash_env_tmpfile = tempfile.mkstemp(suffix=".sh")
             with os.fdopen(fd, "w") as f:
-                f.write(
-                    f'exec 9>>"{coverage_file}"\n'
-                    "if [[ ${BASH_VERSINFO[0]} -ge 4 && ${BASH_VERSINFO[1]} -ge 1 ]]; then\n"
-                    "    export BASH_XTRACEFD=9\n"
-                    "    PS4='+${BASH_SOURCE:-?}:${LINENO} '\n"
-                    "    export PS4\n"
-                    "    set -x\n"
-                    "fi\n"
-                )
+                f.write(coverage_bash_env_script(coverage_file))
             os.environ["BASH_ENV"] = self._bash_env_tmpfile
 
         self._pid, self._master_fd = pty.fork()

--- a/pty_session.py
+++ b/pty_session.py
@@ -156,6 +156,14 @@ class PTYSession:
                 merged = {**os.environ, **self._env}
                 os.execvpe("bash", ["bash", self._script], merged)
             else:
+                # Restore default signal dispositions before exec (see
+                # pty_run.run): inherited SIG_IGN from async bash contexts
+                # would otherwise make the guest TUI unable to trap Ctrl-C.
+                for _sig in (signal.SIGINT, signal.SIGQUIT):
+                    try:
+                        signal.signal(_sig, signal.SIG_DFL)
+                    except (ValueError, OSError, RuntimeError):
+                        pass
                 os.execvp("bash", ["bash", self._script])
             os._exit(1)  # unreachable — execvp replaces the process
 

--- a/pty_snapshot.py
+++ b/pty_snapshot.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""pty_snapshot.py — Screen snapshot assertion for bash-only test suites (#50).
+
+Runs a bash script in a PTY (via PTYSession), sends keys, then compares the
+rendered screen against a stored fixture.
+
+Usage:
+    python3 pty_snapshot.py [--update] <script> <name> [KEY ...]
+
+    KEY tokens are the same as pty_run.py (UP, DOWN, ENTER, q, \\x1b, ...).
+
+Fixture location:
+    $PTYUNIT_SNAPSHOT_DIR/<name>.txt if set, else ./__snapshots__/<name>.txt
+    (relative to the current directory — run your suite from a fixed root).
+
+Behavior:
+    no fixture   → written, notice on stderr, exit 0
+    match        → exit 0
+    mismatch     → unified diff on stderr, exit 1
+    --update / PTYUNIT_UPDATE_SNAPSHOTS=1 → fixture rewritten, exit 0
+    usage/error  → message on stderr, exit 2
+
+Terminal size: PTY_COLS / PTY_ROWS env vars (default 80x24), as pty_run.py.
+
+Typical bash use:
+    assert_true python3 "$PTYUNIT_HOME/pty_snapshot.py" menu.sh main-menu DOWN DOWN
+
+Requires: Python 3.9+, pyte (pip install -r requirements-screen.txt)
+"""
+
+import os
+import sys
+
+from pty_session import PTYSession
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    update = False
+    if args and args[0] == "--update":
+        update = True
+        args = args[1:]
+    if len(args) < 2 or args[0] in ("-h", "--help"):
+        sys.stderr.write(__doc__)
+        return 2
+
+    script, name, keys = args[0], args[1], args[2:]
+    snapshot_dir = os.environ.get("PTYUNIT_SNAPSHOT_DIR") or os.path.join(os.getcwd(), "__snapshots__")
+    cols = int(os.environ.get("PTY_COLS", 80))
+    rows = int(os.environ.get("PTY_ROWS", 24))
+
+    try:
+        with PTYSession(script, cols=cols, rows=rows) as session:
+            for key in keys:
+                session.send(key)
+            try:
+                session.assert_snapshot(name, snapshot_dir=snapshot_dir, update=update)
+            except AssertionError as exc:
+                sys.stderr.write(f"{exc}\n")
+                return 1
+    except (OSError, TimeoutError) as exc:
+        sys.stderr.write(f"pty_snapshot: {exc}\n")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/self-tests/unit/test-assert-float.sh
+++ b/self-tests/unit/test-assert-float.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# self-tests/unit/test-assert-float.sh — float comparison assertions (#52)
+
+set -u
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PTYUNIT_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+source "$PTYUNIT_DIR/assert.sh"
+
+# Run a snippet in a fresh ptyunit process and return its combined output.
+_in_subshell() {
+    bash -c "source '$PTYUNIT_DIR/assert.sh'; $1; ptyunit_test_summary" 2>&1
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "assert_float_eq"
+
+    test_that "passes within default tolerance"
+    assert_float_eq "$(awk 'BEGIN{printf "%.17g", 0.1+0.2}')" 0.3
+
+    test_that "accepts an explicit tolerance"
+    assert_float_eq 1.05 1.0 0.1
+
+    test_that "accepts scientific notation and negative numbers"
+    assert_float_eq 1e-3 0.001
+    assert_float_eq -2.5 -2.50
+
+    test_that "fails outside tolerance with a readable message"
+    out=$(_in_subshell 'assert_float_eq 1.0 1.5 0.1')
+    assert_contains "$out" "FAIL"
+    assert_contains "$out" "1.0"
+    assert_contains "$out" "1.5"
+
+    test_that "rejects non-numeric input as a FAIL, not a silent pass"
+    out=$(_in_subshell 'assert_float_eq abc 1.0')
+    assert_contains "$out" "FAIL"
+    assert_contains "$out" "not a number"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "assert_float_gt / lt / ge / le"
+
+    test_that "compare as floats, not integers"
+    assert_float_gt 2.5 2.4
+    assert_float_lt 2.4 2.5
+    assert_float_ge 2.5 2.5
+    assert_float_le 2.5 2.5
+
+    test_that "gt fails when not greater"
+    out=$(_in_subshell 'assert_float_gt 1.0 2.0')
+    assert_contains "$out" "FAIL"
+
+    test_that "le fails when greater"
+    out=$(_in_subshell 'assert_float_le 2.1 2.0')
+    assert_contains "$out" "FAIL"
+
+ptyunit_test_summary

--- a/self-tests/unit/test-coverage-bash-guard.sh
+++ b/self-tests/unit/test-coverage-bash-guard.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# self-tests/unit/test-coverage-bash-guard.sh — coverage.sh must refuse to run
+# when the `bash` it would trace with lacks BASH_XTRACEFD (< 4.1), instead of
+# silently reporting 0% (#43).
+#
+# Needs a bash < 4.1 on the host (macOS /bin/bash). Skipped elsewhere.
+
+set -u
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PTYUNIT_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+source "$PTYUNIT_DIR/assert.sh"
+
+_old_bash=""
+for _cand in /bin/bash "$(command -v bash)"; do
+    _v=$("$_cand" -c 'printf "%s%02d" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"' 2>/dev/null || echo 999)
+    if (( 10#$_v < 401 )); then _old_bash="$_cand"; break; fi
+done
+
+describe "coverage.sh bash version guard (#43)"
+
+    test_that "exits 2 with a clear message when PATH bash is older than 4.1"
+    if [[ -z "$_old_bash" ]]; then
+        ptyunit_skip_test "no bash < 4.1 on this host"
+    else
+        _bindir=$(mktemp -d "${TMPDIR:-/tmp}/ptyunit-oldbash.XXXXXX")
+        ln -s "$_old_bash" "$_bindir/bash"
+        _out=$(cd "$PTYUNIT_DIR" && PATH="$_bindir:$PATH" "$_old_bash" coverage.sh --unit 2>&1); _rc=$?
+        rm -rf "$_bindir"
+        assert_eq "2" "$_rc"
+        assert_contains "$_out" "bash 4.1"
+        assert_not_contains "$_out" "ptyunit coverage"
+    fi
+
+ptyunit_test_summary

--- a/self-tests/unit/test-mock-hardening.sh
+++ b/self-tests/unit/test-mock-hardening.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# self-tests/unit/test-mock-hardening.sh — Regression tests for mock.sh
+# hardening (issues #39 re-mock leak, #40 name validation, #42 PATH restore).
+
+set -u
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PTYUNIT_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+source "$PTYUNIT_DIR/assert.sh"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "re-mocking a function within one section (#39)"
+
+    ptyunit_hardening_real_fn() { printf 'real'; }
+
+    test_that "second mock in the same section wins"
+    ptyunit_mock ptyunit_hardening_real_fn --output "m1" < /dev/null
+    ptyunit_mock ptyunit_hardening_real_fn --output "m2" < /dev/null
+    assert_eq "m2" "$(ptyunit_hardening_real_fn)"
+
+    test_that "original function is restored at the next section boundary"
+    assert_eq "real" "$(ptyunit_hardening_real_fn 2>&1)"
+
+    test_that "registry holds the name once after re-mocking"
+    ptyunit_mock ptyunit_hardening_real_fn --output "m1" < /dev/null
+    ptyunit_mock ptyunit_hardening_real_fn --output "m2" < /dev/null
+    assert_eq "1" "$(grep -c '^ptyunit_hardening_real_fn$' "$_PTYUNIT_MOCK_DIR/registry")"
+
+    test_that "original function survives a second round of re-mocking"
+    assert_eq "real" "$(ptyunit_hardening_real_fn 2>&1)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "mock name validation (#40)"
+
+    test_that "rejects a name with path traversal"
+    out=$(ptyunit_mock '../ptyunit_evil' 2>&1 < /dev/null); rc=$?
+    assert_eq "2" "$rc"
+    assert_contains "$out" "invalid mock name"
+
+    test_that "rejects a name containing a space"
+    out=$(ptyunit_mock 'git status' 2>&1 < /dev/null); rc=$?
+    assert_eq "2" "$rc"
+    assert_contains "$out" "invalid mock name"
+
+    test_that "rejects a name containing shell metacharacters"
+    out=$(ptyunit_mock 'x;touch /tmp/ptyunit_pwned' 2>&1 < /dev/null); rc=$?
+    assert_eq "2" "$rc"
+    assert_false "[[ -e /tmp/ptyunit_pwned ]]"
+
+    test_that "accepts names with dots and dashes"
+    ptyunit_mock docker-compose.v2 --output "ok" < /dev/null
+    assert_eq "ok" "$(docker-compose.v2)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "PATH restoration (#42)"
+
+    test_that "keeps PATH entries the test added after mocking"
+    ptyunit_mock ptyunit_hardening_cmd --output "ok" < /dev/null
+    PATH="/ptyunit-custom-bin:$PATH"
+
+    test_that "custom entry still present, mock bin gone, after section boundary"
+    assert_contains "$PATH" "/ptyunit-custom-bin:"
+    assert_not_contains "$PATH" "ptyunit-mock"
+    PATH="${PATH#/ptyunit-custom-bin:}"
+
+ptyunit_test_summary

--- a/self-tests/unit/test-mock-hardening.sh
+++ b/self-tests/unit/test-mock-hardening.sh
@@ -63,4 +63,52 @@ describe "PATH restoration (#42)"
     assert_not_contains "$PATH" "ptyunit-mock"
     PATH="${PATH#/ptyunit-custom-bin:}"
 
+# ═════════════════════════════════════════════════════════════════════════════
+describe "function mock bodies run in-process (#41)"
+
+    ptyunit_hardening_helper() { printf 'helper:%s' "$1"; }
+    ptyunit_hardening_target() { printf 'real'; }
+
+    test_that "body can call a caller-defined, non-exported function"
+    ptyunit_mock ptyunit_hardening_target <<'BODY'
+ptyunit_hardening_helper "$1"
+BODY
+    assert_eq "helper:x" "$(ptyunit_hardening_target x 2>&1)"
+
+    test_that "body can set a caller global"
+    PTYUNIT_HARDENING_SEEN=""
+    ptyunit_mock ptyunit_hardening_target <<'BODY'
+PTYUNIT_HARDENING_SEEN="$1"
+BODY
+    ptyunit_hardening_target hello >/dev/null
+    assert_eq "hello" "$PTYUNIT_HARDENING_SEEN"
+
+    test_that "body's return value is the mock's exit status"
+    ptyunit_mock ptyunit_hardening_target <<'BODY'
+return 7
+BODY
+    ptyunit_hardening_target; rc=$?
+    assert_eq "7" "$rc"
+
+    test_that "local is allowed at body top level"
+    ptyunit_mock ptyunit_hardening_target <<'BODY'
+local x="$1"
+printf '%s' "$x"
+BODY
+    assert_eq "loc" "$(ptyunit_hardening_target loc 2>&1)"
+
+    test_that "MOCK_CALL_NUM and call recording still work for in-process bodies"
+    ptyunit_mock ptyunit_hardening_target <<'BODY'
+printf 'call%s' "$MOCK_CALL_NUM"
+BODY
+    ptyunit_hardening_target a >/dev/null
+    assert_eq "call2" "$(ptyunit_hardening_target b 2>&1)"
+    assert_called_with ptyunit_hardening_target b
+
+    test_that "command mock bodies still run as a separate process"
+    ptyunit_mock ptyunit_hardening_cmd2 <<'BODY'
+printf '%s' "$$"
+BODY
+    assert_not_eq "$$" "$(ptyunit_hardening_cmd2)"
+
 ptyunit_test_summary

--- a/self-tests/unit/test-params-sep.sh
+++ b/self-tests/unit/test-params-sep.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# self-tests/unit/test-params-sep.sh — test_each field separator (#49)
+
+set -u
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PTYUNIT_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+source "$PTYUNIT_DIR/assert.sh"
+
+_seen=()
+_cb_record() { _seen+=("$#:$1:${2:-}"); }
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "test_each --sep"
+
+    test_each --sep $'\t' _cb_record <<'PARAMS'
+a|b	c
+x	y|z
+PARAMS
+
+    test_that "tab separator keeps pipes inside values"
+    assert_eq "2:a|b:c" "${_seen[0]}"
+    assert_eq "2:x:y|z" "${_seen[1]}"
+
+    _seen=()
+    test_each --sep , _cb_record <<'PARAMS'
+one,two
+PARAMS
+
+    test_that "any single character works as the separator"
+    assert_eq "2:one:two" "${_seen[0]}"
+
+    test_that "--sep rejects a multi-character separator"
+    out=$(bash -c "
+        source '$PTYUNIT_DIR/assert.sh'
+        _cb() { :; }
+        test_each --sep '::' _cb <<< 'a::b'; printf 'rc=%s\n' \$?
+    " 2>&1)
+    assert_contains "$out" "rc=2"
+    assert_contains "$out" "single character"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "test_each default separator (documented behavior)"
+
+    _seen=()
+    test_each _cb_record <<'PARAMS'
+p|q
+PARAMS
+
+    test_that "default separator is still |"
+    assert_eq "2:p:q" "${_seen[0]}"
+
+    _cnt=""
+    _cb_count() { _cnt="$#"; }
+    test_each _cb_count <<'PARAMS'
+a|b|
+PARAMS
+
+    test_that "a trailing empty field is dropped (read -a semantics)"
+    assert_eq "2" "$_cnt"
+
+ptyunit_test_summary

--- a/self-tests/unit/test-run-stderr.sh
+++ b/self-tests/unit/test-run-stderr.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# self-tests/unit/test-run-stderr.sh — run --separate-stderr, $stderr,
+# assert_success / assert_failure (#48)
+
+set -u
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PTYUNIT_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+source "$PTYUNIT_DIR/assert.sh"
+
+_in_subshell() {
+    bash -c "source '$PTYUNIT_DIR/assert.sh'; $1; ptyunit_test_summary" 2>&1
+}
+
+_both_streams() { echo "to-stdout"; echo "to-stderr" >&2; return 3; }
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "run --separate-stderr"
+
+    test_that "stdout goes to \$output, stderr to \$stderr, exit code to \$status"
+    run --separate-stderr _both_streams
+    assert_eq "to-stdout" "$output"
+    assert_eq "to-stderr" "$stderr"
+    assert_eq "3" "$status"
+    assert_eq "to-stdout" "${lines[0]}"
+
+    test_that "default mode still merges both streams into \$output"
+    run _both_streams
+    assert_contains "$output" "to-stdout"
+    assert_contains "$output" "to-stderr"
+    assert_eq "3" "$status"
+
+    test_that "default mode leaves \$stderr empty (set -u safe)"
+    run _both_streams
+    assert_eq "" "$stderr"
+
+    test_that "separate mode with no stderr output yields empty \$stderr"
+    run --separate-stderr echo "only-out"
+    assert_eq "only-out" "$output"
+    assert_eq "" "$stderr"
+    assert_eq "0" "$status"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "assert_success / assert_failure"
+
+    test_that "assert_success passes when \$status is 0"
+    run true
+    assert_success
+
+    test_that "assert_failure passes on any non-zero status"
+    run _both_streams
+    assert_failure
+
+    test_that "assert_failure with an expected code"
+    run _both_streams
+    assert_failure 3
+
+    test_that "assert_success fails and reports the status and output"
+    out=$(_in_subshell '_f() { echo boom; return 2; }; run _f; assert_success')
+    assert_contains "$out" "FAIL"
+    assert_contains "$out" "status 2"
+    assert_contains "$out" "boom"
+
+    test_that "assert_failure fails when the command succeeded"
+    out=$(_in_subshell 'run true; assert_failure')
+    assert_contains "$out" "FAIL"
+    assert_contains "$out" "status 0"
+
+    test_that "assert_failure N fails when the status differs"
+    out=$(_in_subshell '_f() { return 3; }; run _f; assert_failure 4')
+    assert_contains "$out" "FAIL"
+    assert_contains "$out" "expected status 4"
+    assert_contains "$out" "got status 3"
+
+ptyunit_test_summary

--- a/self-tests/unit/test_pty_run_coverage.py
+++ b/self-tests/unit/test_pty_run_coverage.py
@@ -1,0 +1,75 @@
+"""Tests for pty_run.py BASH_ENV coverage injection guard (#44).
+
+pty_run.run() must not enable xtrace in a child bash that lacks
+BASH_XTRACEFD (< 4.1): on those versions `set -x` writes to stderr, which
+*is* the PTY, so trace lines pollute the captured output.
+
+The 3.2 test needs an old bash on the host (macOS /bin/bash) and is skipped
+elsewhere; the modern-bash test runs everywhere.
+"""
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from pty_run import run
+
+
+def _bash_version(path):
+    out = subprocess.run(
+        [path, "-c", 'printf "%s %s" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"'],
+        capture_output=True, text=True,
+    ).stdout.split()
+    return int(out[0]), int(out[1])
+
+
+def _find_old_bash():
+    """Return a path to a bash < 4.1, or None."""
+    for cand in ("/bin/bash", shutil.which("bash")):
+        if cand and os.path.exists(cand) and _bash_version(cand) < (4, 1):
+            return cand
+    return None
+
+
+@pytest.fixture
+def script(tmp_path):
+    s = tmp_path / "tui.sh"
+    s.write_text('printf "MENU\\n"; read -r -n1 k; printf "got=%s\\n" "$k"\n')
+    return str(s)
+
+
+@pytest.fixture
+def cov_file(tmp_path):
+    f = tmp_path / "cov.trace"
+    f.touch()
+    return str(f)
+
+
+def _run_with_bash(bash_path, script, cov_file, monkeypatch, tmp_path):
+    """Run pty_run.run() with `bash` resolving to bash_path via PATH."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    os.symlink(bash_path, bindir / "bash")
+    monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+    return run(script, ["q"], coverage_file=cov_file, timeout=5)
+
+
+def test_old_bash_child_output_has_no_xtrace_lines(script, cov_file, monkeypatch, tmp_path):
+    old = _find_old_bash()
+    if old is None:
+        pytest.skip("no bash < 4.1 on this host")
+    out, rc = _run_with_bash(old, script, cov_file, monkeypatch, tmp_path)
+    assert rc == 0
+    assert "got=q" in out
+    assert "\n+" not in ("\n" + out), f"xtrace leaked into PTY output:\n{out}"
+
+
+def test_modern_bash_child_still_writes_coverage_trace(script, cov_file, monkeypatch, tmp_path):
+    modern = shutil.which("bash")
+    if _bash_version(modern) < (4, 1):
+        pytest.skip("PATH bash is < 4.1")
+    out, rc = _run_with_bash(modern, script, cov_file, monkeypatch, tmp_path)
+    assert rc == 0
+    assert "\n+" not in ("\n" + out)
+    assert os.path.getsize(cov_file) > 0, "coverage trace should be non-empty on bash >= 4.1"

--- a/self-tests/unit/test_pty_run_expect.py
+++ b/self-tests/unit/test_pty_run_expect.py
@@ -1,0 +1,72 @@
+"""Tests for pty_run --expect: a per-key checkpoint for bash-only suites (#51).
+
+An ("expect", text) item in the key list — or `--expect text` on the CLI —
+requires *text* to be in the cumulative stripped output after the preceding
+key settles. On a miss, no further keys are sent and the exit code is 65
+(EX_DATAERR) with a diagnostic on stderr.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+from pty_run import run
+
+PTY_RUN = os.path.join(os.path.dirname(os.path.abspath(run.__code__.co_filename)), "pty_run.py")
+
+
+@pytest.fixture
+def script(tmp_path):
+    s = tmp_path / "two-keys.sh"
+    s.write_text(
+        'printf "MENU\\n"\n'
+        'read -r -n1 k; printf "got=%s\\n" "$k"\n'
+        'read -r -n1 k; printf "got2=%s\\n" "$k"\n'
+    )
+    return str(s)
+
+
+def test_expect_passes_when_text_is_present(script):
+    out, rc = run(script, ["a", ("expect", "got=a"), "b"], timeout=5)
+    assert rc == 0
+    assert "got2=b" in out
+
+
+def test_expect_failure_stops_sending_and_exits_65(script):
+    out, rc = run(script, ["a", ("expect", "MISSING"), "b"], timeout=5)
+    assert rc == 65
+    assert "got=a" in out
+    assert "got2=" not in out, "keys after a failed --expect must not be sent"
+
+
+def test_expect_before_any_key_checks_initial_render(script):
+    out, rc = run(script, [("expect", "MENU"), "a", "b"], timeout=5)
+    assert rc == 0
+
+
+def test_cli_expect_syntax(script):
+    ok = subprocess.run(
+        [sys.executable, PTY_RUN, script, "a", "--expect", "got=a", "b"],
+        capture_output=True, text=True, timeout=20,
+    )
+    assert ok.returncode == 0, ok.stderr
+    assert "got2=b" in ok.stdout
+
+    bad = subprocess.run(
+        [sys.executable, PTY_RUN, script, "a", "--expect", "MISSING", "b"],
+        capture_output=True, text=True, timeout=20,
+    )
+    assert bad.returncode == 65
+    assert "--expect" in bad.stderr
+    assert "MISSING" in bad.stderr
+    assert "got2=" not in bad.stdout
+
+
+def test_cli_expect_without_argument_is_a_usage_error(script):
+    r = subprocess.run(
+        [sys.executable, PTY_RUN, script, "a", "--expect"],
+        capture_output=True, text=True, timeout=20,
+    )
+    assert r.returncode == 64  # EX_USAGE
+    assert "--expect" in r.stderr

--- a/self-tests/unit/test_pty_run_strip.py
+++ b/self-tests/unit/test_pty_run_strip.py
@@ -1,0 +1,35 @@
+"""Tests for pty_run.strip_ansi — the output-cleaning path used by run().
+
+A child killed mid-escape-sequence (timeout) leaves a truncated prefix such
+as b"\\x1b[3" at the end of the buffer. ANSI_RE alone cannot match it (no
+final byte), so the raw ESC would leak into "stripped" output (#45).
+"""
+import pytest
+
+from pty_run import strip_ansi
+
+
+@pytest.mark.parametrize("raw, expected", [
+    (b"plain", b"plain"),
+    (b"\x1b[1mbold\x1b[0m", b"bold"),
+    (b"a\r\nb\rc", b"a\nb\nc"),
+])
+def test_strips_complete_sequences_and_normalizes_newlines(raw, expected):
+    assert strip_ansi(raw) == expected
+
+
+@pytest.mark.parametrize("raw, expected", [
+    (b"ok\x1b[3", b"ok"),          # truncated CSI
+    (b"ok\x1b[", b"ok"),           # bare CSI opener
+    (b"ok\x1b", b"ok"),            # bare ESC
+    (b"ok\x1b]0;title", b"ok"),    # truncated OSC
+    (b"ok\x1bP1$r", b"ok"),        # truncated DCS
+])
+def test_drops_trailing_incomplete_sequence(raw, expected):
+    assert strip_ansi(raw) == expected
+
+
+def test_incomplete_sequence_only_dropped_at_end():
+    # An ESC in the middle followed by a real sequence must still strip
+    # normally; nothing before the tail is touched.
+    assert strip_ansi(b"a\x1b[1mb\x1b[") == b"ab"

--- a/self-tests/unit/test_snapshot.py
+++ b/self-tests/unit/test_snapshot.py
@@ -1,0 +1,133 @@
+"""Tests for screen snapshot assertions (#50).
+
+Screen.text() gives a normalized full-screen string; PTYSession.assert_snapshot()
+compares it against a stored fixture (__snapshots__/<name>.txt beside the
+calling test file unless snapshot_dir is given), writing the fixture on first
+use and rewriting it when update=True or PTYUNIT_UPDATE_SNAPSHOTS=1.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+import pty_session
+from pty_session import PTYSession
+
+PTYUNIT_DIR = os.path.dirname(os.path.abspath(pty_session.__file__))
+PTY_SNAPSHOT = os.path.join(PTYUNIT_DIR, "pty_snapshot.py")
+
+
+@pytest.fixture
+def script(tmp_path):
+    s = tmp_path / "box.sh"
+    s.write_text(
+        'printf "+----+\\n"\n'
+        'printf "| hi |   \\n"\n'      # trailing spaces must be stripped
+        'printf "+----+\\n"\n'
+        'read -r -n1 k\n'
+        'printf "bye\\n"\n'
+    )
+    return str(s)
+
+
+def test_screen_text_strips_trailing_spaces_and_blank_rows(script):
+    with PTYSession(script, cols=20, rows=6) as s:
+        text = s.screen.text()
+        s.send("q")
+    assert text == "+----+\n| hi |\n+----+"
+
+
+def test_first_run_writes_fixture_and_passes(script, tmp_path, capsys):
+    snap_dir = tmp_path / "snaps"
+    with PTYSession(script, cols=20, rows=6) as s:
+        s.assert_snapshot("box", snapshot_dir=str(snap_dir))
+        s.send("q")
+    fixture = snap_dir / "box.txt"
+    assert fixture.read_text() == "+----+\n| hi |\n+----+\n"
+    assert "wrote new snapshot" in capsys.readouterr().err
+
+
+def test_matching_fixture_passes(script, tmp_path):
+    snap_dir = tmp_path / "snaps"
+    snap_dir.mkdir()
+    (snap_dir / "box.txt").write_text("+----+\n| hi |\n+----+\n")
+    with PTYSession(script, cols=20, rows=6) as s:
+        s.assert_snapshot("box", snapshot_dir=str(snap_dir))
+        s.send("q")
+
+
+def test_mismatch_raises_with_unified_diff(script, tmp_path):
+    snap_dir = tmp_path / "snaps"
+    snap_dir.mkdir()
+    (snap_dir / "box.txt").write_text("+----+\n| yo |\n+----+\n")
+    with PTYSession(script, cols=20, rows=6) as s:
+        with pytest.raises(AssertionError) as exc:
+            s.assert_snapshot("box", snapshot_dir=str(snap_dir))
+        s.send("q")
+    msg = str(exc.value)
+    assert "-| yo |" in msg
+    assert "+| hi |" in msg
+    assert "box.txt" in msg
+
+
+def test_update_flag_rewrites_fixture(script, tmp_path):
+    snap_dir = tmp_path / "snaps"
+    snap_dir.mkdir()
+    (snap_dir / "box.txt").write_text("stale\n")
+    with PTYSession(script, cols=20, rows=6) as s:
+        s.assert_snapshot("box", snapshot_dir=str(snap_dir), update=True)
+        s.send("q")
+    assert (snap_dir / "box.txt").read_text() == "+----+\n| hi |\n+----+\n"
+
+
+def test_update_env_var_rewrites_fixture(script, tmp_path, monkeypatch):
+    monkeypatch.setenv("PTYUNIT_UPDATE_SNAPSHOTS", "1")
+    snap_dir = tmp_path / "snaps"
+    snap_dir.mkdir()
+    (snap_dir / "box.txt").write_text("stale\n")
+    with PTYSession(script, cols=20, rows=6) as s:
+        s.assert_snapshot("box", snapshot_dir=str(snap_dir))
+        s.send("q")
+    assert (snap_dir / "box.txt").read_text() == "+----+\n| hi |\n+----+\n"
+
+
+def test_default_snapshot_dir_is_beside_calling_test_file(script, tmp_path):
+    # Write a tiny test module in tmp_path and run it with pytest so the
+    # "calling file" is that module, not this one.
+    mod = tmp_path / "test_caller.py"
+    mod.write_text(
+        "import sys\n"
+        f"sys.path.insert(0, {PTYUNIT_DIR!r})\n"
+        "from pty_session import PTYSession\n"
+        "def test_it():\n"
+        f"    with PTYSession({script!r}, cols=20, rows=6) as s:\n"
+        "        s.assert_snapshot('beside')\n"
+        "        s.send('q')\n"
+    )
+    r = subprocess.run([sys.executable, "-m", "pytest", "-q", str(mod)],
+                       capture_output=True, text=True, timeout=60, cwd=str(tmp_path))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert (tmp_path / "__snapshots__" / "beside.txt").exists()
+
+
+def test_cli_pass_then_mismatch(script, tmp_path):
+    # The CLI snapshots *after* sending keys, so the echoed "q" and the
+    # script's "bye" line are part of the expected screen here.
+    expected = "+----+\n| hi |\n+----+\nqbye\n"
+    env = {**os.environ, "PTYUNIT_SNAPSHOT_DIR": str(tmp_path / "cli")}
+    first = subprocess.run([sys.executable, PTY_SNAPSHOT, script, "box", "q"],
+                           capture_output=True, text=True, timeout=30, env=env)
+    assert first.returncode == 0, first.stderr
+    assert (tmp_path / "cli" / "box.txt").read_text() == expected
+
+    (tmp_path / "cli" / "box.txt").write_text("nope\n")
+    second = subprocess.run([sys.executable, PTY_SNAPSHOT, script, "box", "q"],
+                            capture_output=True, text=True, timeout=30, env=env)
+    assert second.returncode == 1
+    assert "+| hi |" in second.stderr
+
+    third = subprocess.run([sys.executable, PTY_SNAPSHOT, "--update", script, "box", "q"],
+                           capture_output=True, text=True, timeout=30, env=env)
+    assert third.returncode == 0, third.stderr
+    assert (tmp_path / "cli" / "box.txt").read_text() == expected


### PR DESCRIPTION
## Summary

Implements all 14 issues filed from the 2026-08-24 external review (#39–#52), one commit per issue, each with a failing self-test written first. Verified locally on macOS bash 3.2 and 5.x.

Closes #39, closes #40, closes #41, closes #42, closes #43, closes #44, closes #45, closes #46, closes #47, closes #48, closes #49, closes #50, closes #51, closes #52.

## Bug fixes

| Commit | Issue | Change |
|---|---|---|
| `c5fa47b` | #39 #40 #42 | mock.sh: re-mocking a function in one section no longer leaks mock #1 as the "original"; mock names validated (`^[A-Za-z_][A-Za-z0-9_.-]*$`, rc 2); PATH cleanup strips only the mock bin dir instead of restoring a snapshot |
| `c290b9f` | #44 | `pty_run.coverage_bash_env_script()` shared with PTYSession; bash-4.1 guard on both drivers (pty_run lacked it → a 3.2 child spewed xtrace into PTY output under coverage); guard now includes bash 5.0 |
| `8255220` | #43 | `coverage.sh` exits 2 on bash < 4.1 instead of silently reporting 0%; README and header comment corrected (the described 3.2 fallback never existed) |
| `00dcba7` | #45 | `strip_ansi()` drops a trailing incomplete escape **before** `ANSI_RE` — otherwise the Fe catch-all eats `ESC ]`/`ESC P` and leaks a truncated OSC/DCS payload |
| `c0e5320` | #41 | Function-mock heredoc bodies run in-process (sourced inside a helper fn, so `local`/`return` work and caller functions/globals are visible). Command mocks unchanged. No consumer repo uses heredoc bodies. |

## Features

| Commit | Issue | Change |
|---|---|---|
| `154559b` | #49 | `test_each --sep CHAR` for values containing pipes; no-escape and trailing-empty-field rules documented |
| `3ba3fce` | #52 | `assert_float_eq/gt/lt/ge/le` (awk, tolerance, non-numeric input is a FAIL) |
| `4e00ee6` | #48 | `run --separate-stderr` → `$stderr`; `assert_success` / `assert_failure [code]`. Default `run` keeps the interleaved stream and sets `$stderr=""` (bats convention) |
| `38c99b3` | #51 | `pty_run.py --expect TEXT` per-key checkpoint: exit 65 on miss with diagnostic, 64 on missing arg. Also fixes a latent double-`waitpid` when the child exits during the key loop |
| `0bdb59b` | #50 | `Screen.text()`, `PTYSession.assert_snapshot(name, *, snapshot_dir, update)`, and `pty_snapshot.py [--update] <script> <name> [KEY…]` for bash suites; `PTYUNIT_UPDATE_SNAPSHOTS=1` to accept changes |

## Docs

| Commit | Issue | Change |
|---|---|---|
| `38e03c5` | #46 | `PTY_INIT`/`init_delay` marked ignored (since v1.5.2); "any program" claim corrected to "runs `bash <script>`" with the exec-wrapper idiom; Windows = WSL only |
| `1cf54a8` | #47 | README section for `PTYSession` (API table, where `test_*.py` go, the `conftest.py` line consumers need) |
| `01f25a8` `e017eb8` | — | PROJECT.md session-30 handoff + overview corrections |

## Test plan

- [x] `bash run.sh --unit` — 724/724 across 38 files (main: 648/648)
- [x] `bash run.sh --integration` — 37/37
- [x] New/changed bash self-tests also run under `/bin/bash` 3.2.57
- [x] `coverage.sh` still starts on bash 5.x; exits 2 with message on 3.2
- [ ] Docker matrix (CI on this PR) — watch Alpine busybox `awk` for #52 and `read -a` on 4.4 for #49

## After merge

Features added → **v1.6.0** (`bash release.sh minor`), then bump the Homebrew tap; consumers install via Homebrew, no submodule bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
