### PR TITLE
fix(run): flaky "in 1.0 secs" timing on coarse clocks (bash 3.2/4.4 CI legs)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -93,13 +93,57 @@ USAGE
     exit 0
 }
 
-# ── Timing helper ─────────────────────────────────────────────────────────────
+# ── Timing helpers ────────────────────────────────────────────────────────────
+# _ptyunit_now prints the current time as "S" (integer seconds) or "S.uuuuuu".
+#   bash >= 5:  EPOCHREALTIME (microseconds).
+#   otherwise:  `date +%s%N` when the platform's date honors %N (GNU coreutils,
+#               macOS). busybox date — the Alpine CI containers — silently drops
+#               %N and yields integer seconds: a coarse clock.
+_PTYUNIT_DATE_NS=""   # lazily detected per process: 1 = date supports %N, 0 = no
+
 _ptyunit_now() {
     if [[ "${BASH_VERSINFO[0]}" -ge 5 ]]; then
         printf '%s' "${EPOCHREALTIME}"
+        return
+    fi
+    if [[ -z "$_PTYUNIT_DATE_NS" ]]; then
+        local _probe
+        _probe=$(date +%s%N 2>/dev/null)
+        if [[ "$_probe" =~ ^[0-9]{16,}$ ]]; then _PTYUNIT_DATE_NS=1; else _PTYUNIT_DATE_NS=0; fi
+    fi
+    if (( _PTYUNIT_DATE_NS )); then
+        local _ns _len
+        _ns=$(date +%s%N)
+        _len=${#_ns}
+        printf '%s.%s' "${_ns:0:_len-9}" "${_ns:_len-9:6}"
     else
         date +%s
     fi
+}
+
+# _ptyunit_elapsed T0 T1 prints the elapsed seconds between two _ptyunit_now
+# stamps as "S.t" (one decimal). Two integer stamps mean a coarse clock, which
+# cannot tell a 10 ms test that straddled a second boundary from a 1.9 s one —
+# so a delta of 1 is reported as fast ("0.0"); a delta of N >= 2 guarantees at
+# least N-1 real seconds and is reported as-is. (Previously a straddle showed
+# "in 1.0 secs" and flaked the "fast tests omit elapsed" self-test on the
+# bash 3.2/4.4 Alpine legs.)
+_ptyunit_elapsed() {
+    local _t0="$1" _t1="$2"
+    if [[ "$_t0" != *.* && "$_t1" != *.* ]]; then
+        local _d=$(( _t1 - _t0 ))
+        if (( _d <= 1 )); then printf '0.0'; else printf '%d.0' "$_d"; fi
+        return
+    fi
+    local _s0="${_t0%.*}" _f0="${_t0#*.}" _s1="${_t1%.*}" _f1="${_t1#*.}"
+    [[ "$_t0" == *.* ]] || _f0=0
+    [[ "$_t1" == *.* ]] || _f1=0
+    # Pad fractional parts to 6 digits
+    _f0="${_f0}000000"; _f0="${_f0:0:6}"
+    _f1="${_f1}000000"; _f1="${_f1:0:6}"
+    local _us=$(( (_s1 * 1000000 + 10#$_f1) - (_s0 * 1000000 + 10#$_f0) ))
+    (( _us < 0 )) && _us=0
+    printf '%d.%d' $(( _us / 1000000 )) $(( (_us / 100000) % 10 ))
 }
 
 # ── XML escaping helper for JUnit output ─────────────────────────────────────
@@ -152,24 +196,7 @@ _run_job() {
     local rc=$?
     _t1=$(_ptyunit_now)
     local _raw_elapsed
-    if [[ "${BASH_VERSINFO[0]}" -ge 5 ]]; then
-        # EPOCHREALTIME gives microsecond precision as a string "SECONDS.MICROSECONDS"
-        # Compute difference using integer arithmetic on the whole and fractional parts
-        local _s0="${_t0%.*}" _f0="${_t0#*.}" _s1="${_t1%.*}" _f1="${_t1#*.}"
-        # Pad fractional parts to 6 digits
-        _f0="${_f0}000000"; _f0="${_f0:0:6}"
-        _f1="${_f1}000000"; _f1="${_f1:0:6}"
-        local _us=$(( (_s1 * 1000000 + 10#$_f1) - (_s0 * 1000000 + 10#$_f0) ))
-        if (( _us < 0 )); then _us=0; fi
-        local _secs=$(( _us / 1000000 ))
-        local _tenths=$(( (_us / 100000) % 10 ))
-        _raw_elapsed="${_secs}.${_tenths}"
-    else
-        # date +%s gives integer seconds
-        _raw_elapsed=$(( _t1 - _t0 ))
-        # Append .0 for consistent format
-        _raw_elapsed="${_raw_elapsed}.0"
-    fi
+    _raw_elapsed=$(_ptyunit_elapsed "$_t0" "$_t1")
     if [[ "$_raw_elapsed" == "0.0" ]]; then
         _elapsed="< 0.1"
     else
@@ -248,19 +275,7 @@ _run_py_job() {
     local rc=$?
     _t1=$(_ptyunit_now)
 
-    if [[ "${BASH_VERSINFO[0]}" -ge 5 ]]; then
-        local _s0="${_t0%.*}" _f0="${_t0#*.}" _s1="${_t1%.*}" _f1="${_t1#*.}"
-        _f0="${_f0}000000"; _f0="${_f0:0:6}"
-        _f1="${_f1}000000"; _f1="${_f1:0:6}"
-        local _us=$(( (_s1 * 1000000 + 10#$_f1) - (_s0 * 1000000 + 10#$_f0) ))
-        if (( _us < 0 )); then _us=0; fi
-        local _secs=$(( _us / 1000000 ))
-        local _tenths=$(( (_us / 100000) % 10 ))
-        _raw_elapsed="${_secs}.${_tenths}"
-    else
-        _raw_elapsed=$(( _t1 - _t0 ))
-        _raw_elapsed="${_raw_elapsed}.0"
-    fi
+    _raw_elapsed=$(_ptyunit_elapsed "$_t0" "$_t1")
     if [[ "$_raw_elapsed" == "0.0" ]]; then
         _elapsed="< 0.1"
     else

--- a/self-tests/unit/test-run-timing.sh
+++ b/self-tests/unit/test-run-timing.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# self-tests/unit/test-run-timing.sh — per-file elapsed-time computation in
+# run.sh. A fast test on a coarse (integer-second) clock can straddle a second
+# boundary and read as "1 second"; that must be reported as fast, not as
+# "in 1.0 secs" (flaky CI on Alpine busybox `date`, bash 3.2/4.4 legs).
+set -u
+PTYUNIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+source "$PTYUNIT_DIR/assert.sh"
+
+# ── Required globals (run.sh has set -u; initialize before sourcing) ─────────
+_verbose=0; _fail_fast=0; _fail_sentinel=""; _format="pretty"; _jobs=1; _filter=""
+_OK_LABEL="OK"; _FAIL_LABEL="FAIL"; _SKIP_LABEL="SKIP"
+_suite_work_dirs=(); _suite_labels=()
+_total_pass=0; _total_fail=0; _total_files=0; _total_skip=0
+_failed_files=(); _skipped_files=()
+
+source "$PTYUNIT_DIR/run.sh"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "_ptyunit_elapsed on a coarse (integer-second) clock"
+
+    test_that "a 1-second delta is ambiguous (0.001–1.999 s) and reported as fast"
+    assert_eq "0.0" "$(_ptyunit_elapsed 100 101)"
+
+    test_that "a zero delta is fast"
+    assert_eq "0.0" "$(_ptyunit_elapsed 100 100)"
+
+    test_that "a 2-second delta is at least 1 s and is reported"
+    assert_eq "2.0" "$(_ptyunit_elapsed 100 102)"
+
+    test_that "a negative delta (clock step) clamps to fast"
+    assert_eq "0.0" "$(_ptyunit_elapsed 105 100)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "_ptyunit_elapsed on a fractional clock"
+
+    test_that "tenths are computed across a second boundary"
+    assert_eq "1.2" "$(_ptyunit_elapsed 100.500000 101.700000)"
+
+    test_that "a short interval across a boundary is not rounded up to a second"
+    assert_eq "0.1" "$(_ptyunit_elapsed 100.950000 101.050000)"
+
+    test_that "sub-tenth intervals are fast"
+    assert_eq "0.0" "$(_ptyunit_elapsed 100.100000 100.150000)"
+
+    test_that "short fractional parts are padded, not misread"
+    assert_eq "0.5" "$(_ptyunit_elapsed 100.5 101)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "_ptyunit_now"
+
+    test_that "returns integer seconds or seconds with a 6-digit fraction"
+    _now=$(_ptyunit_now)
+    assert_match '^[0-9]+(\.[0-9]{6})?$' "$_now"
+
+    test_that "uses a sub-second clock when date supports %N, even on bash < 5"
+    if [[ "$(date +%s%N 2>/dev/null)" =~ ^[0-9]{16,}$ ]]; then
+        _now=$(_ptyunit_now)
+        assert_match '^[0-9]+\.[0-9]{6}$' "$_now"
+    else
+        ptyunit_skip_test "date +%N unsupported on this host (coarse clock)"
+    fi
+
+ptyunit_test_summary


### PR DESCRIPTION
## Summary

The `tests` workflow failed on the v1.6.0 release push (`2907322`) in **Unit tests (bash 3.2)**, TAP step: `test-runner.sh` → "timing: fast tests omit elapsed by default" saw `in 1.0 secs`. The release commit only touched `VERSION`/`package.json`; the rerun passed. Root cause is pre-existing flakiness: on bash < 5 the per-file timer is integer `date +%s`, and the Alpine containers' busybox `date` ignores `%N`, so any fast file that straddles a second boundary reads as 1 s.

## Fix

- `_ptyunit_now`: use `date +%s%N` where the platform honors `%N` (GNU coreutils, macOS) → sub-second timing on bash 3.2/4.x there. busybox stays coarse.
- New `_ptyunit_elapsed T0 T1`, shared by the bash and Python workers. On a coarse clock a delta of 1 is ambiguous (0.001–1.999 s) and is reported as fast (`0.0` → hidden / `< 0.1` in verbose); a delta of N ≥ 2 guarantees ≥ N−1 real seconds and is shown.
- The Python worker had a duplicate copy of the arithmetic that assumed integer stamps on bash < 5; it now calls the shared helper.

## Tests

New `self-tests/unit/test-run-timing.sh` (10 cases): coarse-clock deltas 0/1/2/negative, fractional deltas across boundaries, short-fraction padding, `_ptyunit_now` format, and sub-second output on bash < 5 when `date +%N` works.

- [x] `bash run.sh --unit` (bash 5.3): 734/734 across 39 files
- [x] `/bin/bash run.sh --unit` (3.2.57 as the runner): 734/734
- [x] `bash run.sh --integration`: 37/37
- [x] `test-runner.sh` ×5 under /bin/bash 3.2: all green
- [ ] Alpine matrix (CI on this PR) — the legs that actually flaked

## Follow-up (separate ticket)

While iterating, a worker that crashed before writing its `.res` file deadlocked the runner (semaphore token never returned) instead of failing the file — a robustness gap worth closing independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
