### PR TITLE
fix(run): report a worker that dies before writing results instead of hanging (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Failed files:
 | `-v` / `--verbose` | Show timing for every file |
 | `--version` | Print version and exit |
 
-> **How parallelism works:** Tests run in a streaming worker pool using an fd-based semaphore. This is compatible with bash 3.2 — no `wait -n` or GNU `parallel` required. Files start as soon as a slot opens rather than waiting for all files to be discovered first.
+> **How parallelism works:** Tests run in a streaming worker pool using an fd-based semaphore. This is compatible with bash 3.2 — no `wait -n` or GNU `parallel` required. Files start as soon as a slot opens rather than waiting for all files to be discovered first. A worker that dies before reporting (killed, or a fatal error in the runner) is detected within ~2 s, reported as `FAIL (worker did not report)`, and its slot is recycled — the suite never hangs on it.
 
 ### File-level setUp / tearDown
 

--- a/run.sh
+++ b/run.sh
@@ -314,6 +314,37 @@ _run_py_job() {
     fi
 }
 
+# ── Dead-worker sweep ─────────────────────────────────────────────────────────
+# A worker returns its pool token and writes <name>.done as its last acts. If
+# the worker process is gone but never wrote .done, it died before reporting —
+# a fatal bash error in the runner, or a kill — and its token is lost. Without
+# this sweep the parent would block forever on the semaphore (files > jobs) or
+# silently drop the file from the totals (files <= jobs) (#55).
+#
+# Usage: _ptyunit_sweep_dead_workers <work_dir> <sem_fd> <col> [pid:file ...]
+# For each gone-without-.done worker: synthesize a FAIL (.out/.res/.raw) if it
+# left no .res, return one token to <sem_fd>, and mark it .swept so it is only
+# handled once. Returns 0 if anything was swept, 1 otherwise.
+_ptyunit_sweep_dead_workers() {
+    local work_dir="$1" _fd="$2" _col="$3"; shift 3
+    local _swept=1 _pair _pid _f _name
+    for _pair in "$@"; do
+        _pid="${_pair%%:*}"; _f="${_pair#*:}"; _name="${_f##*/}"
+        [[ -f "$work_dir/$_name.swept" ]] && continue
+        kill -0 "$_pid" 2>/dev/null && continue        # still running
+        [[ -f "$work_dir/$_name.done" ]] && continue   # finished normally
+        if [[ ! -f "$work_dir/$_name.res" ]]; then
+            printf '  %-*s ... %s (worker did not report)\n' "$_col" "$_name" "$_FAIL_LABEL" > "$work_dir/$_name.out"
+            printf '1 0 1 0.0\n' > "$work_dir/$_name.res"
+            printf 'worker did not report: the test worker process exited before writing results (killed, or a fatal error in the runner)\n' > "$work_dir/$_name.raw"
+        fi
+        : > "$work_dir/$_name.swept"
+        printf 'x' >&"$_fd"
+        _swept=0
+    done
+    return $_swept
+}
+
 # ── Suite runner: streaming worker pool ──────────────────────────────────────
 # Uses an fd-based semaphore for bash 3.2-compatible bounded parallelism.
 # Jobs start as soon as a slot opens — scanner and workers are interleaved.
@@ -378,8 +409,13 @@ _run_suite() {
     local i
     for (( i=0; i<_jobs; i++ )); do printf 'x' >&4; done
 
+    local _workers=()               # "pid:file" per started worker (#55)
     for f in "${files[@]}"; do
-        read -r -n1 -u4 _tok        # acquire slot (blocks when pool is full)
+        # Acquire a slot. The read blocks while the pool is full; every 2 s
+        # without a token, sweep for workers that died without returning one.
+        while ! read -r -n1 -u4 -t 2 _tok; do
+            _ptyunit_sweep_dead_workers "$work_dir" 4 "$_col" "${_workers[@]+"${_workers[@]}"}" || true
+        done
         # Check fail-fast after a worker finishes (token released)
         if (( _fail_fast )) && [[ -n "${_fail_sentinel:-}" ]] && [[ -f "$_fail_sentinel" ]]; then
             break
@@ -387,10 +423,13 @@ _run_suite() {
         (
             _run_job "$f" "$setUp_file" "$tearDown_file" "$work_dir" "$_col"
             printf 'x' >&4          # release slot
+            : > "$work_dir/${f##*/}.done"
         ) &
+        _workers+=("$!:$f")
     done
 
     wait                            # drain all remaining workers
+    _ptyunit_sweep_dead_workers "$work_dir" 4 "$_col" "${_workers[@]+"${_workers[@]}"}" || true
     exec 4>&-
 
     # Print pretty results and aggregate counts
@@ -480,18 +519,24 @@ _run_py_suite() {
     local i
     for (( i=0; i<_jobs; i++ )); do printf 'x' >&5; done
 
+    local _workers=()               # "pid:file" per started worker (#55)
     for f in "${files[@]}"; do
-        read -r -n1 -u5 _tok
+        while ! read -r -n1 -u5 -t 2 _tok; do
+            _ptyunit_sweep_dead_workers "$work_dir" 5 "$_col" "${_workers[@]+"${_workers[@]}"}" || true
+        done
         if (( _fail_fast )) && [[ -n "${_fail_sentinel:-}" ]] && [[ -f "$_fail_sentinel" ]]; then
             break
         fi
         (
             _run_py_job "$f" "$work_dir" "$_col"
             printf 'x' >&5
+            : > "$work_dir/${f##*/}.done"
         ) &
+        _workers+=("$!:$f")
     done
 
     wait
+    _ptyunit_sweep_dead_workers "$work_dir" 5 "$_col" "${_workers[@]+"${_workers[@]}"}" || true
     exec 5>&-
 
     for f in "${files[@]}"; do

--- a/self-tests/unit/test-runner-dead-worker.sh
+++ b/self-tests/unit/test-runner-dead-worker.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# self-tests/unit/test-runner-dead-worker.sh — a worker that dies before writing
+# its .res file must be reported as FAIL and must not deadlock or silently
+# drop the file (#55).
+#
+# Fixtures kill the worker from setUp.sh: setUp runs as a direct child of the
+# worker subshell, so `kill -9 $PPID` there takes the worker down before it can
+# report or return its pool token.
+set -u
+PTYUNIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$PTYUNIT_DIR/assert.sh"
+
+# Run a command with a wall-clock cap; sets _wd_out / _wd_rc. A run that hits
+# the cap is killed and _wd_out gets a __WATCHDOG_TIMEOUT__ marker.
+_run_with_watchdog() {
+    local _limit="$1"; shift
+    local _outf; _outf=$(mktemp)
+    "$@" > "$_outf" 2>&1 &
+    local _pid=$! _i=0
+    while kill -0 "$_pid" 2>/dev/null; do
+        if (( _i >= _limit )); then
+            kill -9 "$_pid" 2>/dev/null
+            printf '__WATCHDOG_TIMEOUT__\n' >> "$_outf"
+            break
+        fi
+        sleep 1; (( _i++ ))
+    done
+    wait "$_pid" 2>/dev/null; _wd_rc=$?
+    _wd_out=$(<"$_outf"); rm -f "$_outf"
+}
+
+_mk_suite() {   # _mk_suite <dir> <kill-on-nth-setUp> <file names...>
+    local _dir="$1" _nth="$2"; shift 2
+    mkdir -p "$_dir/tests/unit"
+    local _f
+    for _f in "$@"; do
+        cat > "$_dir/tests/unit/$_f" << FIXTURE
+source "$PTYUNIT_DIR/assert.sh"
+assert_eq "x" "x" "$_f passes"
+ptyunit_test_summary
+FIXTURE
+    done
+    cat > "$_dir/tests/unit/setUp.sh" << FIXTURE
+n=\$(cat "$_dir/count" 2>/dev/null || echo 0); n=\$(( n + 1 )); echo "\$n" > "$_dir/count"
+(( n == $_nth )) && kill -9 \$PPID
+exit 0
+FIXTURE
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "worker killed while more files are queued (files > jobs)"
+
+    _d1=$(mktemp -d); _mk_suite "$_d1" 2 test-a.sh test-b.sh test-c.sh
+    _run_with_watchdog 25 bash -c "cd '$_d1' && bash '$PTYUNIT_DIR/run.sh' --unit --jobs 1"
+
+    test_that "the suite completes instead of deadlocking on the pool semaphore"
+    assert_not_contains "$_wd_out" "__WATCHDOG_TIMEOUT__"
+
+    test_that "the dead worker's file is reported as FAIL with a reason"
+    assert_match 'test-b\.sh +\.\.\. FAIL' "$_wd_out"
+    assert_contains "$_wd_out" "worker did not report"
+
+    test_that "the files after it still run"
+    assert_match 'test-c\.sh +\.\.\. OK' "$_wd_out"
+
+    test_that "totals count the dead file and the run exits 1"
+    assert_contains "$_wd_out" "2/3 assertions passed across 3 file(s)"
+    assert_contains "$_wd_out" "test-b.sh"
+    assert_eq "1" "$_wd_rc"
+    rm -rf "$_d1"
+
+# ═════════════════════════════════════════════════════════════════════════════
+describe "worker killed with no files queued (files <= jobs)"
+
+    _d2=$(mktemp -d); _mk_suite "$_d2" 1 test-x.sh
+    _run_with_watchdog 25 bash -c "cd '$_d2' && bash '$PTYUNIT_DIR/run.sh' --unit --jobs 4"
+
+    test_that "the file is not silently dropped from the results"
+    assert_not_contains "$_wd_out" "__WATCHDOG_TIMEOUT__"
+    assert_match 'test-x\.sh +\.\.\. FAIL' "$_wd_out"
+    assert_contains "$_wd_out" "0/1 assertions passed across 1 file(s)"
+    assert_eq "1" "$_wd_rc"
+
+    test_that "TAP output marks it not ok with the reason as a diagnostic"
+    rm -f "$_d2/count"
+    _run_with_watchdog 25 bash -c "cd '$_d2' && bash '$PTYUNIT_DIR/run.sh' --unit --jobs 4 --format tap"
+    assert_contains "$_wd_out" "not ok 1 - test-x.sh"
+    assert_contains "$_wd_out" "worker did not report"
+    rm -rf "$_d2"
+
+ptyunit_test_summary


### PR DESCRIPTION
## Summary

Closes #55.

A worker that exited before writing `<name>.res` (fatal bash error in the runner, or a kill) never returned its pool token. Two failure modes, both fixed:

- **files > jobs:** the parent blocked forever on the semaphore — a hung CI job until the runner timeout, no diagnostic.
- **files ≤ jobs:** `wait` returned and the file silently vanished from the totals; TAP printed it as `ok # SKIP did not run`.

## Fix

Parent-side (a worker-side EXIT trap can't cover SIGKILL):

- Acquire slots with `read -t 2`; on each timeout, and once after `wait`, run `_ptyunit_sweep_dead_workers` over the started `pid:file` list.
- A worker whose process is gone but that never wrote `<name>.done` died before reporting → synthesize `FAIL (worker did not report)` (`.out`/`.res`/`.raw`, so pretty/TAP/JUnit all show it) and return one token. `.swept` marker makes it idempotent.
- Workers write `.done` **after** returning the token, so "reported, then died before returning the token" is recovered too; the only benign race is a possible extra token in the printf→touch window.
- Same change in the bash and Python pools. Fast path is unchanged — `read` returns immediately whenever a token is available.

## Tests

`self-tests/unit/test-runner-dead-worker.sh` (13 assertions): a fixture `setUp.sh` does `kill -9 $PPID` on its Nth invocation (setUp runs as a direct child of the worker subshell), under a 25 s watchdog.
- files > jobs (`--jobs 1`, kill the 2nd): completes, `test-b.sh … FAIL (worker did not report)`, `test-c.sh … OK`, `2/3 across 3 file(s)`, rc 1
- files ≤ jobs (`--jobs 4`, single file): not dropped — `0/1 across 1 file(s)`, rc 1
- `--format tap`: `not ok 1 - test-x.sh` with the reason as a diagnostic

Before the fix the first case hit the watchdog (deadlock reproduced).

- [x] `bash run.sh --unit` (bash 5.3): 747/747 across 40 files
- [x] `/bin/bash run.sh --unit` (3.2.57 as runner): 747/747
- [x] `bash run.sh --integration`: 37/37
- [ ] Alpine matrix (CI on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
